### PR TITLE
Implementing babel-plugin-module-alias

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,14 @@
 {
-  "presets": ["react-native"]
+  "presets": ["react-native"],
+  "plugins": [
+    [
+      "module-alias",
+      [
+        {
+          "src": "./src",
+          "expose": "kitsu"
+        },
+      ]
+    ]
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -13,5 +13,10 @@
     "no-use-before-define": ["error", { "functions": false, "variables": false }],
     "react/forbid-prop-types": 0,
     "class-methods-use-this": 0
+  },
+  "settings": {
+    "import/resolver": {
+      "babel-module-alias": {}
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,23 +55,27 @@
   },
   "devDependencies": {
     "babel-jest": "20.0.3",
+    "babel-plugin-module-alias": "^1.6.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react-native": "1.9.2",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.1",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint-import-resolver-babel-module-alias": "^1.5.1",
+    "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^5.0.3",
     "eslint-plugin-react": "^7.0.1",
     "jest": "20.0.3",
     "prettier-eslint": "^6.2.2",
     "react-native-debugger-open": "^0.3.12",
-    "redux-logger": "^3.0.6",
-    "react-test-renderer": "16.0.0-alpha.6"
+    "react-test-renderer": "16.0.0-alpha.6",
+    "redux-logger": "^3.0.6"
   },
   "jest": {
     "preset": "react-native"
   },
   "rnpm": {
-    "assets": ["src/assets/fonts"]
+    "assets": [
+      "src/assets/fonts"
+    ]
   }
 }

--- a/src/actions/fetchUserFeed.js
+++ b/src/actions/fetchUserFeed.js
@@ -1,5 +1,5 @@
+import { Kitsu } from 'kitsu/config/api';
 import types from './types';
-import { Kitsu } from '../config/api';
 
 const fetchUserFeed = () => async (dispatch, getState) => {
   // dispatch({

--- a/src/components/Card/CardActivity.js
+++ b/src/components/Card/CardActivity.js
@@ -1,4 +1,4 @@
-import React, { Component, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
 import { Button, Left, Right, Thumbnail } from 'native-base';
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -6,10 +6,10 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 // import HTMLView from 'react-native-htmlview';
 
-import ProgressiveImage from '../../components/ProgressiveImage';
-import HTMLView from '../../components/htmlView';
-import * as colors from '../../constants/colors';
-import { defaultAvatar } from '../../constants/app';
+import ProgressiveImage from 'kitsu/components/ProgressiveImage';
+import HTMLView from 'kitsu/components/htmlView';
+import * as colors from 'kitsu/constants/colors';
+import { defaultAvatar } from 'kitsu/constants/app';
 
 class CardActivity extends PureComponent {
   shouldComponentUpdate() {

--- a/src/components/Card/CardStatus.js
+++ b/src/components/Card/CardStatus.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { View, Text, TextInput } from 'react-native';
-import { Button, Left, Right, Thumbnail } from 'native-base';
+import { View, TextInput } from 'react-native';
+import { Thumbnail } from 'native-base';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
-import { defaultAvatar } from '../../constants/app';
+import { defaultAvatar } from 'kitsu/constants/app';
 
 import Card from './Card';
 

--- a/src/components/CardTabBar.js
+++ b/src/components/CardTabBar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { Button, Text, View } from 'native-base';
-import * as colors from '../constants/colors';
+import * as colors from 'kitsu/constants/colors';
 
 const SimpleTabBar = React.createClass({
   tabIcons: [],

--- a/src/components/CustomHeader.js
+++ b/src/components/CustomHeader.js
@@ -1,10 +1,7 @@
 import React from 'react';
-import { View, Dimensions, Text, Image } from 'react-native';
+import { View, Dimensions, Text } from 'react-native';
 import { Button, Icon, Left, Right } from 'native-base';
-
 import LinearGradient from 'react-native-linear-gradient';
-import ProgressiveImage from './ProgressiveImage';
-import { defaultCover } from '../constants/app';
 
 const CustomHeader = ({
   navigation,

--- a/src/components/Forms/LoginForm.js
+++ b/src/components/Forms/LoginForm.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { PropTypes } from 'prop-types';
 import { Form, Input, Item, Button, Spinner } from 'native-base';
-import CustomIcon from '../Icon';
-import * as colors from '../../constants/colors';
+import * as colors from 'kitsu/constants/colors';
+import CustomIcon from 'kitsu/components/Icon';
+
 
 const LoginForm = ({ handleChange, data, onSubmit, loading }) => (
   <View>

--- a/src/components/Forms/RecoveryForm.js
+++ b/src/components/Forms/RecoveryForm.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { View, Text } from 'react-native';
 import { PropTypes } from 'prop-types';
 import { Form, Input, Item, Button, Spinner } from 'native-base';
-import CustomIcon from '../Icon';
-import * as colors from '../../constants/colors';
+import CustomIcon from 'kitsu/components/Icon';
+import * as colors from 'kitsu/constants/colors';
 
 const RecoveryForm = ({ handleChange, data, onSubmit, loading }) => (
   <View>

--- a/src/components/Forms/SignupForm.js
+++ b/src/components/Forms/SignupForm.js
@@ -3,7 +3,7 @@ import { View, Text } from 'react-native';
 import { PropTypes } from 'prop-types';
 import { Button, Spinner } from 'native-base';
 import t from 'tcomb-form-native';
-import * as colors from '../../constants/colors';
+import * as colors from 'kitsu/constants/colors';
 import textbox from './tcomb/textbox';
 
 const { Form } = t.form;

--- a/src/components/Forms/tcomb/textbox.js
+++ b/src/components/Forms/tcomb/textbox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { View, Text } from 'react-native';
 import { Input, Item } from 'native-base';
-import CustomIcon from '../../Icon';
+import CustomIcon from 'kitsu/components/Icon';
 
 function textbox(locals) {
   if (locals.hidden) {

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { createIconSetFromFontello } from 'react-native-vector-icons';
-import config from '../assets/fonts/icons/config.json';
+import config from 'kitsu/assets/fonts/icons/config.json';
 
 const Icon = createIconSetFromFontello(config);
 

--- a/src/components/MediaUploader/MediaFilter.js
+++ b/src/components/MediaUploader/MediaFilter.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import { Text, TouchableOpacity } from 'react-native';
 import PropTypes from 'prop-types';
 import Icon from 'react-native-vector-icons/FontAwesome';
-
-import * as colors from '../../constants/colors';
+import * as colors from 'kitsu/constants/colors';
 
 export default class MediaFilter extends Component {
   static propTypes = {

--- a/src/components/MediaUploader/MediaFilterMenu.js
+++ b/src/components/MediaUploader/MediaFilterMenu.js
@@ -4,7 +4,7 @@ import { Body, Card, CardItem } from 'native-base';
 import PropTypes from 'prop-types';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
-import * as colors from '../../constants/colors';
+import * as colors from 'kitsu/constants/colors';
 
 export default class MediaFilterMenu extends Component {
   static propTypes = {

--- a/src/components/MediaUploader/MediaSelectionGrid.js
+++ b/src/components/MediaUploader/MediaSelectionGrid.js
@@ -9,7 +9,7 @@ import {
   View,
 } from 'react-native';
 
-import * as colors from '../../constants/colors';
+import * as colors from 'kitsu/constants/colors';
 
 import Thumbnail from './Thumbnail';
 

--- a/src/components/MediaUploader/Thumbnail.js
+++ b/src/components/MediaUploader/Thumbnail.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
 import Icon from 'react-native-vector-icons/FontAwesome';
 
-import * as colors from '../../constants/colors';
+import * as colors from 'kitsu/constants/colors';
 
 export default class Thumbnail extends PureComponent {
   static propTypes = {

--- a/src/components/ProgressiveImage.js
+++ b/src/components/ProgressiveImage.js
@@ -2,9 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, Animated } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
-
-import * as colors from '../constants/colors';
-import { defaultAvatar } from '../constants/app';
+import * as colors from 'kitsu/constants/colors';
 
 let i = 0;
 const genKey = () => `key:${++i}`;

--- a/src/components/SegmentTabBar.js
+++ b/src/components/SegmentTabBar.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
-import { Segment, Button, Text, StyleProvider, View } from 'native-base';
+import { Segment, Button, Text, StyleProvider } from 'native-base';
+import * as colors from 'kitsu/constants/colors';
 import getTheme from '../../native-base-theme/components';
 import kitsuStyles from '../../native-base-theme/variables/kitsu';
-import * as colors from '../constants/colors';
 
 const SegmentTabBar = React.createClass({
   tabIcons: [],

--- a/src/components/SimpleTabBar.js
+++ b/src/components/SimpleTabBar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { StyleSheet } from 'react-native';
 import { Button, Text, View } from 'native-base';
-import * as colors from '../constants/colors';
 
 const SimpleTabBar = React.createClass({
   tabIcons: [],

--- a/src/routes/filter.js
+++ b/src/routes/filter.js
@@ -1,7 +1,7 @@
 import { StackNavigator } from 'react-navigation';
-import SearchFilter from '../screens/Search/SearchFilter';
-import FilterSub from '../screens/Search/FilterSub';
-import SearchCategory from '../screens/Search/SearchCategory';
+import SearchFilter from 'kitsu/screens/Search/SearchFilter';
+import FilterSub from 'kitsu/screens/Search/FilterSub';
+import SearchCategory from 'kitsu/screens/Search/SearchCategory';
 import navigationOptions from './navigationOptions';
 
 const FilterStack = StackNavigator(

--- a/src/routes/navigationOptions.js
+++ b/src/routes/navigationOptions.js
@@ -1,4 +1,4 @@
-import { darkPurple, white } from '../constants/colors';
+import { darkPurple, white } from 'kitsu/constants/colors';
 
 export default (headerHeight = 64, marginTop = 0) => ({
   headerStyle: { backgroundColor: darkPurple, height: headerHeight },

--- a/src/routes/notification.js
+++ b/src/routes/notification.js
@@ -1,5 +1,5 @@
 import { StackNavigator } from 'react-navigation';
-import NotificationsScreen from '../screens/Notifications/NotificationsScreen';
+import NotificationsScreen from 'kitsu/screens/Notifications/NotificationsScreen';
 import navigationOptions from './navigationOptions';
 
 const NotifStack = StackNavigator(

--- a/src/routes/post.js
+++ b/src/routes/post.js
@@ -1,7 +1,7 @@
 import { StackNavigator } from 'react-navigation';
+import PostCreation from 'kitsu/screens/PostCreation';
+import MediaUploadScreen from 'kitsu/screens/PostCreation/MediaUploadScreen';
 import navigationOptions from './navigationOptions';
-import PostCreation from '../screens/PostCreation';
-import MediaUploadScreen from '../screens/PostCreation/MediaUploadScreen';
 
 const PostStack = StackNavigator(
   {

--- a/src/routes/profile.js
+++ b/src/routes/profile.js
@@ -1,4 +1,4 @@
-import DismissableStackNavigator from '../components/DismissableStackNavigator';
+import DismissableStackNavigator from 'kitsu/components/DismissableStackNavigator';
 import {
   MediaScreen,
   CustomLibScreen,
@@ -6,7 +6,7 @@ import {
   FavoriteCharacters,
   NetworkScreen,
   FavoriteMedia,
-} from '../screens/Profiles';
+} from 'kitsu/screens/Profiles';
 import navigationOptions from './navigationOptions';
 
 const ProfileStack = DismissableStackNavigator(

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -1,7 +1,7 @@
 import { StackNavigator } from 'react-navigation';
-import SearchScreen from '../screens/Search/SearchScreen';
-import SearchCategory from '../screens/Search/SearchCategory';
-import SearchResults from '../screens/Search/SearchResults';
+import SearchScreen from 'kitsu/screens/Search/SearchScreen';
+import SearchCategory from 'kitsu/screens/Search/SearchCategory';
+import SearchResults from 'kitsu/screens/Search/SearchResults';
 import navigationOptions from './navigationOptions';
 
 const SearchStack = StackNavigator(

--- a/src/routes/tabs.js
+++ b/src/routes/tabs.js
@@ -1,15 +1,12 @@
 import React from 'react';
 import { TabNavigator } from 'react-navigation';
 import { connect } from 'react-redux';
-
-import HomeScreen from '../screens/HomeScreen';
+import HomeScreen from 'kitsu/screens/HomeScreen';
+import { fetchCurrentUser } from 'kitsu/store/user/actions';
+import { tabRed, listBackPurple } from 'kitsu/constants/colors';
 import SearchStack from './search';
 import NotifStack from './notification';
 import ProfileStack from './profile';
-
-import { fetchCurrentUser } from '../store/user/actions';
-
-import { tabRed, listBackPurple } from '../constants/colors';
 
 const Tabs = TabNavigator(
   {

--- a/src/screens/Auth/AuthWrapper.js
+++ b/src/screens/Auth/AuthWrapper.js
@@ -3,10 +3,9 @@ import PropTypes from 'prop-types';
 import { Text, Image } from 'react-native';
 import { LoginManager } from 'react-native-fbsdk';
 import { Container, Content, Footer, FooterTab, Button } from 'native-base';
-
-import * as colors from '../../constants/colors';
-import CustomIcon from '../../components/Icon';
-import AnimatedWrapper from '../../components/AnimatedWrapper';
+import * as colors from 'kitsu/constants/colors';
+import CustomIcon from 'kitsu/components/Icon';
+import AnimatedWrapper from 'kitsu/components/AnimatedWrapper';
 
 const AuthWrapper = ({ onSuccess, children, loading }) => {
   const loginFacebook = () => {

--- a/src/screens/Auth/LoginScreen.js
+++ b/src/screens/Auth/LoginScreen.js
@@ -4,9 +4,9 @@ import { View, Text } from 'react-native';
 import { Button } from 'native-base';
 import { connect } from 'react-redux';
 
-import * as colors from '../../constants/colors';
-import LoginForm from '../../components/Forms/LoginForm';
-import { loginUser } from '../../store/auth/actions';
+import * as colors from 'kitsu/constants/colors';
+import LoginForm from 'kitsu/components/Forms/LoginForm';
+import { loginUser } from 'kitsu/store/auth/actions';
 import AuthWrapper from './AuthWrapper';
 
 class LoginScreen extends Component {

--- a/src/screens/Auth/RecoveryScreen.js
+++ b/src/screens/Auth/RecoveryScreen.js
@@ -5,9 +5,9 @@ import { Button } from 'native-base';
 import { connect } from 'react-redux';
 import { NavigationActions } from 'react-navigation';
 
-import * as colors from '../../constants/colors';
-import RecoveryForm from '../../components/Forms/RecoveryForm';
-import { loginUser } from '../../store/auth/actions';
+import * as colors from 'kitsu/constants/colors';
+import RecoveryForm from 'kitsu/components/Forms/RecoveryForm';
+import { loginUser } from 'kitsu/store/auth/actions';
 import AuthWrapper from './AuthWrapper';
 
 class RecoveryScreen extends Component {

--- a/src/screens/Auth/SignupScreen.js
+++ b/src/screens/Auth/SignupScreen.js
@@ -5,9 +5,9 @@ import { Button } from 'native-base';
 import { connect } from 'react-redux';
 import { NavigationActions } from 'react-navigation';
 
-import SignupForm from '../../components/Forms/SignupForm';
-import { loginUser } from '../../store/auth/actions';
-import { createUser } from '../../store/user/actions';
+import SignupForm from 'kitsu/components/Forms/SignupForm';
+import { loginUser } from 'kitsu/store/auth/actions';
+import { createUser } from 'kitsu/store/user/actions';
 import AuthWrapper from './AuthWrapper';
 
 class SignupScreen extends Component {

--- a/src/screens/Auth/SplashScreen.js
+++ b/src/screens/Auth/SplashScreen.js
@@ -5,8 +5,8 @@ import PropTypes from 'prop-types';
 import { NavigationActions } from 'react-navigation';
 import Animation from 'lottie-react-native';
 
-import anim from '../../assets/animation/kitsu.json';
-import * as colors from '../../constants/colors';
+import anim from 'kitsu/assets/animation/kitsu.json';
+import * as colors from 'kitsu/constants/colors';
 
 class SplashScreen extends Component {
   static navigationOptions = {

--- a/src/screens/Feed/index.js
+++ b/src/screens/Feed/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { View, FlatList, Text } from 'react-native';
+import { View } from 'react-native';
 import { connect } from 'react-redux';
-import { fetchUserFeed } from '../../actions';
+import { fetchUserFeed } from 'kitsu/actions';
 
 class Feed extends React.Component {
   componentDidMount() {

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -3,8 +3,7 @@ import { View, Text, Image } from 'react-native';
 import { connect } from 'react-redux';
 import { Spinner, Button, Container, Content, Icon } from 'native-base';
 import PropTypes from 'prop-types';
-
-import { logoutUser } from '../store/auth/actions';
+import { logoutUser } from 'kitsu/store/auth/actions';
 
 class HomeScreen extends Component {
   static navigationOptions = {

--- a/src/screens/Notifications/NotificationsScreen.js
+++ b/src/screens/Notifications/NotificationsScreen.js
@@ -6,8 +6,8 @@ import Icon from 'react-native-vector-icons/FontAwesome';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-import * as colors from '../../constants/colors';
-import { getNotifications, seenNotifications } from '../../store/feed/actions';
+import * as colors from 'kitsu/constants/colors';
+import { getNotifications, seenNotifications } from 'kitsu/store/feed/actions';
 
 class NotificationsScreen extends Component {
   static navigationOptions = ({ screenProps }) => ({

--- a/src/screens/Onboarding/OnboardingScreen.js
+++ b/src/screens/Onboarding/OnboardingScreen.js
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import { View, Text, Dimensions } from 'react-native';
 import { Container, Content, Footer, FooterTab, Button } from 'native-base';
 import Carousel from 'react-native-snap-carousel';
+import * as colors from 'kitsu/constants/colors';
 import styles from './styles';
 import Step from './Step';
 import Dot from './Dot';
-import * as colors from '../../constants/colors';
+
 
 const styleObj = {
   container: {

--- a/src/screens/Onboarding/styles.js
+++ b/src/screens/Onboarding/styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import * as colors from '../../constants/colors';
+import * as colors from 'kitsu/constants/colors';
 
 export default StyleSheet.create({
   container: {

--- a/src/screens/PostCreation/MediaUploadScreen.js
+++ b/src/screens/PostCreation/MediaUploadScreen.js
@@ -3,7 +3,7 @@ import { Text, View } from 'react-native';
 import { Button } from 'native-base';
 import PropTypes from 'prop-types';
 
-import { MediaFilter, MediaFilterMenu, MediaSelectionGrid } from '../../components/MediaUploader';
+import { MediaFilter, MediaFilterMenu, MediaSelectionGrid } from 'kitsu/components/MediaUploader';
 
 export default class MediaUploadScreen extends Component {
   static navigationOptions = ({ navigation }) => ({

--- a/src/screens/PostCreation/styles.js
+++ b/src/screens/PostCreation/styles.js
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { white, darkPurple } from '../../constants/colors';
+import { white } from 'kitsu/constants/colors';
 
 const styles = StyleSheet.create({
   container: {

--- a/src/screens/Profiles/CustomLibScreen.js
+++ b/src/screens/Profiles/CustomLibScreen.js
@@ -8,20 +8,14 @@ import {
   Text,
   TextInput,
   Image,
-  Easing,
   Animated,
-  TouchableHighlight,
 } from 'react-native';
 import Swipeable from 'react-native-swipeable';
 import { connect } from 'react-redux';
 import { Icon, Button, Container } from 'native-base';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 import AweIcon from 'react-native-vector-icons/FontAwesome';
-import { OptimizedFlatList } from 'react-native-optimized-flatlist';
-
-import SimpleTabBar from '../../components/SimpleTabBar';
-import ProgressiveImage from '../../components/ProgressiveImage';
-import Swiper from '../../components/Swiper';
+import SimpleTabBar from 'kitsu/components/SimpleTabBar';
 
 const { width } = Dimensions.get('window');
 

--- a/src/screens/Profiles/FavoriteCharacters.js
+++ b/src/screens/Profiles/FavoriteCharacters.js
@@ -3,11 +3,10 @@ import PropTypes from 'prop-types';
 import { View, Text, Dimensions, FlatList } from 'react-native';
 import { connect } from 'react-redux';
 import { Icon, Button, Container } from 'native-base';
-
-import ProgressiveImage from '../../components/ProgressiveImage';
-import { defaultAvatar } from '../../constants/app';
-import { fetchProfileFavorites } from '../../store/profile/actions';
-import { fetchMediaCastings } from '../../store/media/actions';
+import ProgressiveImage from 'kitsu/components/ProgressiveImage';
+import { defaultAvatar } from 'kitsu/constants/app';
+import { fetchProfileFavorites } from 'kitsu/store/profile/actions';
+import { fetchMediaCastings } from 'kitsu/store/media/actions';
 
 class FavoriteCharacter extends Component {
   static navigationOptions = ({ navigation }) => ({

--- a/src/screens/Profiles/FavoriteMedia.js
+++ b/src/screens/Profiles/FavoriteMedia.js
@@ -5,9 +5,9 @@ import { connect } from 'react-redux';
 import { Icon, Button, Container } from 'native-base';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 
-import SimpleTabBar from '../../components/SimpleTabBar';
-import ProgressiveImage from '../../components/ProgressiveImage';
-import { fetchProfileFavorites } from '../../store/profile/actions';
+import SimpleTabBar from 'kitsu/components/SimpleTabBar';
+import ProgressiveImage from 'kitsu/components/ProgressiveImage';
+import { fetchProfileFavorites } from 'kitsu/store/profile/actions';
 
 class FavoriteMedia extends Component {
   static navigationOptions = ({ navigation }) => ({

--- a/src/screens/Profiles/LibraryScreen.js
+++ b/src/screens/Profiles/LibraryScreen.js
@@ -14,9 +14,7 @@ import { connect } from 'react-redux';
 import { Icon, Button, Container } from 'native-base';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 import AweIcon from 'react-native-vector-icons/FontAwesome';
-
-import SimpleTabBar from '../../components/SimpleTabBar';
-import ProgressiveImage from '../../components/ProgressiveImage';
+import SimpleTabBar from 'kitsu/components/SimpleTabBar';
 
 const { width } = Dimensions.get('window');
 class LibraryScreen extends Component {

--- a/src/screens/Profiles/MediaScreen.js
+++ b/src/screens/Profiles/MediaScreen.js
@@ -15,20 +15,19 @@ import PropTypes from 'prop-types';
 import LinearGradient from 'react-native-linear-gradient';
 import * as Animatable from 'react-native-animatable';
 import _ from 'lodash';
-
-import CustomHeader from '../../components/CustomHeader';
-import DoubleProgress from '../../components/DoubleProgress';
-import CardStatus from '../../components/Card/CardStatus';
-import CardFull from '../../components/Card/CardFull';
-import CardActivity from '../../components/Card/CardActivity';
-import ProgressiveImage from '../../components/ProgressiveImage';
-import { defaultAvatar } from '../../constants/app';
-import getTitleField from '../../utils/getTitleField';
-import { fetchMedia, fetchMediaReactions, fetchMediaCastings } from '../../store/media/actions';
-import { getMediaFeed } from '../../store/feed/actions';
-import * as colors from '../../constants/colors';
+import CustomHeader from 'kitsu/components/CustomHeader';
+import DoubleProgress from 'kitsu/components/DoubleProgress';
+import CardStatus from 'kitsu/components/Card/CardStatus';
+import CardFull from 'kitsu/components/Card/CardFull';
+import CardActivity from 'kitsu/components/Card/CardActivity';
+import ProgressiveImage from 'kitsu/components/ProgressiveImage';
+import getTitleField from 'kitsu/utils/getTitleField';
+import { fetchMedia, fetchMediaReactions, fetchMediaCastings } from 'kitsu/store/media/actions';
+import { getMediaFeed } from 'kitsu/store/feed/actions';
+import * as colors from 'kitsu/constants/colors';
 import ParallaxScrollView from 'react-native-parallax-scroll-view';
-import { defaultCover } from '../../constants/app';
+import { defaultAvatar, defaultCover } from 'kitsu/constants/app';
+
 const { width } = Dimensions.get('window');
 
 class MediaScreen extends Component {

--- a/src/screens/Profiles/NetworkScreen.js
+++ b/src/screens/Profiles/NetworkScreen.js
@@ -13,10 +13,9 @@ import { connect } from 'react-redux';
 import { Icon, Button, Container, Spinner } from 'native-base';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
 import AweIcon from 'react-native-vector-icons/FontAwesome';
-
-import SimpleTabBar from '../../components/SimpleTabBar';
-import { fetchNetwork } from '../../store/profile/actions';
-import { defaultAvatar } from '../../constants/app';
+import SimpleTabBar from 'kitsu/components/SimpleTabBar';
+import { fetchNetwork } from 'kitsu/store/profile/actions';
+import { defaultAvatar } from 'kitsu/constants/app';
 
 const { width } = Dimensions.get('window');
 class NetworkScreen extends Component {

--- a/src/screens/Profiles/ProfileScreen.js
+++ b/src/screens/Profiles/ProfileScreen.js
@@ -15,30 +15,28 @@ import PropTypes from 'prop-types';
 import { Col, Grid } from 'react-native-easy-grid';
 import _ from 'lodash';
 import moment from 'moment';
-
-import CustomHeader from '../../components/CustomHeader';
-import Card from '../../components/Card/Card';
-import CardStatus from '../../components/Card/CardStatus';
-import CardFull from '../../components/Card/CardFull';
-import CardTabs from '../../components/Card/CardTabs';
-import CardActivity from '../../components/Card/CardActivity';
-import ProgressiveImage from '../../components/ProgressiveImage';
-import * as colors from '../../constants/colors';
-import { defaultAvatar } from '../../constants/app';
-import ResultsList from '../../screens/Search/Lists/ResultsList';
+import CustomHeader from 'kitsu/components/CustomHeader';
+import CardStatus from 'kitsu/components/Card/CardStatus';
+import CardFull from 'kitsu/components/Card/CardFull';
+import CardTabs from 'kitsu/components/Card/CardTabs';
+import CardActivity from 'kitsu/components/Card/CardActivity';
+import ProgressiveImage from 'kitsu/components/ProgressiveImage';
+import * as colors from 'kitsu/constants/colors';
+import { defaultAvatar } from 'kitsu/constants/app';
+import ResultsList from 'kitsu/screens/Search/Lists/ResultsList';
 import ParallaxScrollView from 'react-native-parallax-scroll-view';
-import { defaultCover } from '../../constants/app';
+import { defaultCover } from 'kitsu/constants/app';
 import {
   fetchProfile,
   fetchProfileFavorites,
   fetchLibraryEntires,
-} from '../../store/profile/actions';
-import { getUserFeed } from '../../store/feed/actions';
+} from 'kitsu/store/profile/actions';
+import { getUserFeed } from 'kitsu/store/feed/actions';
 
 const Loader = <Spinner size="small" color="grey" />;
 
 class ProfileScreen extends Component {
-  
+
   static navigationOptions = ({ navigation }) => ({
     tabBarIcon: ({ tintColor }) => (
       <Icon ios="ios-body" android="md-body" style={{ fontSize: 20, color: tintColor }} />

--- a/src/screens/Search/FilterSub.js
+++ b/src/screens/Search/FilterSub.js
@@ -5,8 +5,8 @@ import { Button, Container, Content, Icon, Left, Right, Footer } from 'native-ba
 import PropTypes from 'prop-types';
 import MultiSlider from 'react-native-multi-slider';
 
-import { getCategories } from '../../store/anime/actions';
-import * as colors from '../../constants/colors';
+import { getCategories } from 'kitsu/store/anime/actions';
+import * as colors from 'kitsu/constants/colors';
 
 const width = Dimensions.get('screen').width - 40;
 

--- a/src/screens/Search/Lists/ResultsList.js
+++ b/src/screens/Search/Lists/ResultsList.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View, FlatList, Text, TouchableOpacity } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
-import ProgressiveImage from '../../../components/ProgressiveImage';
+import ProgressiveImage from 'kitsu/components/ProgressiveImage';
 
 const ResultsList = ({
   dataArray,

--- a/src/screens/Search/Lists/TopsList.js
+++ b/src/screens/Search/Lists/TopsList.js
@@ -4,10 +4,9 @@ import { connect } from 'react-redux';
 import { Icon, Left, Right, Button, Text, Item } from 'native-base';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
-
-import * as colors from '../../../constants/colors';
-import { getDefaults } from '../../../store/anime/actions';
-import ProgressiveImage from '../../../components/ProgressiveImage';
+import * as colors from 'kitsu/constants/colors';
+import { getDefaults } from 'kitsu/store/anime/actions';
+import ProgressiveImage from 'kitsu/components/ProgressiveImage';
 
 const list = [
   { label: 'Release date', key: 'release' },

--- a/src/screens/Search/SearchCategory.js
+++ b/src/screens/Search/SearchCategory.js
@@ -6,9 +6,9 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import IconAwe from 'react-native-vector-icons/FontAwesome';
 import { CheckBox } from 'react-native-elements';
-import { getCategories } from '../../store/anime/actions';
-import { genres } from '../../utils/genres';
-import * as colors from '../../constants/colors';
+import { getCategories } from 'kitsu/store/anime/actions';
+import { genres } from 'kitsu/utils/genres';
+import * as colors from 'kitsu/constants/colors';
 
 class SearchCategory extends Component {
   static navigationOptions = ({ navigation }) => ({

--- a/src/screens/Search/SearchFilter.js
+++ b/src/screens/Search/SearchFilter.js
@@ -5,8 +5,8 @@ import { Button, Container, Content, Icon, Left, Right, Footer } from 'native-ba
 import PropTypes from 'prop-types';
 import ModalPicker from 'react-native-modal-picker';
 import _ from 'lodash';
-import { getStreamers } from '../../store/anime/actions';
-import * as colors from '../../constants/colors';
+import { getStreamers } from 'kitsu/store/anime/actions';
+import * as colors from 'kitsu/constants/colors';
 
 class SearchFilter extends Component {
   static navigationOptions = () => ({

--- a/src/screens/Search/SearchResults.js
+++ b/src/screens/Search/SearchResults.js
@@ -4,8 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Icon, Button } from 'native-base';
 import AweIcon from 'react-native-vector-icons/FontAwesome';
-
-import { search } from '../../store/anime/actions';
+import { search } from 'kitsu/store/anime/actions';
 import { ResultsList } from './Lists';
 
 class SearchResults extends Component {

--- a/src/screens/Search/SearchScreen.js
+++ b/src/screens/Search/SearchScreen.js
@@ -1,16 +1,13 @@
 import React, { Component } from 'react';
 import { StyleSheet, ScrollView } from 'react-native';
 import { connect } from 'react-redux';
-import { Container, Icon, Text, Item, Input, Image } from 'native-base';
+import { Container, Icon, Item, Input } from 'native-base';
 import PropTypes from 'prop-types';
 import ScrollableTabView from 'react-native-scrollable-tab-view';
-import _ from 'lodash';
-
-import * as colors from '../../constants/colors';
-
-import { search } from '../../store/anime/actions';
+import * as colors from 'kitsu/constants/colors';
+import { search } from 'kitsu/store/anime/actions';
+import SegmentTabBar from 'kitsu/components/SegmentTabBar';
 import { ResultsList, TopsList, UsersList } from './Lists';
-import SegmentTabBar from '../../components/SegmentTabBar';
 
 class SearchScreen extends Component {
   static navigationOptions = {

--- a/src/store/anime/actions.js
+++ b/src/store/anime/actions.js
@@ -1,5 +1,5 @@
-import * as types from '../types';
-import { Kitsu } from '../../config/api';
+import { Kitsu } from 'kitsu/config/api';
+import * as types from 'kitsu/store/types';
 
 const defaults = {
   popular: {

--- a/src/store/anime/reducer.js
+++ b/src/store/anime/reducer.js
@@ -1,4 +1,4 @@
-import * as types from '../types';
+import * as types from 'kitsu/store/types';
 
 const INITIAL_STATE = {
   topAiringanime: [],

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -1,8 +1,8 @@
 import { AccessToken, GraphRequest, GraphRequestManager } from 'react-native-fbsdk';
 import { NavigationActions } from 'react-navigation';
-import * as types from '../types';
-import { auth } from '../../config/api';
-import { kitsuConfig } from '../../config/env';
+import { auth } from 'kitsu/config/api';
+import { kitsuConfig } from 'kitsu/config/env';
+import * as types from 'kitsu/store/types';
 
 export const loginUser = (data, nav, screen) => async (dispatch) => {
   dispatch({ type: types.LOGIN_USER });

--- a/src/store/auth/reducer.js
+++ b/src/store/auth/reducer.js
@@ -1,5 +1,5 @@
 import { REHYDRATE } from 'redux-persist/constants';
-import * as types from '../types';
+import * as types from 'kitsu/store/types';
 
 const INITIAL_STATE = {
   signingIn: false,

--- a/src/store/feed/actions.js
+++ b/src/store/feed/actions.js
@@ -1,6 +1,6 @@
-import * as types from '../types';
-import { Kitsu } from '../../config/api';
-import { getStream } from '../../config/stream';
+import * as types from 'kitsu/store/types';
+import { Kitsu } from 'kitsu/config/api';
+import { getStream } from 'kitsu/config/stream';
 
 const feedInclude =
   'media,actor,unit,subject,target,target.user,target.target_user,target.spoiled_unit,target.media,target.target_group,subject.user,subject.target_user,subject.spoiled_unit,subject.media,subject.target_group,subject.followed,subject.library_entry,subject.anime,subject.manga';

--- a/src/store/feed/reducer.js
+++ b/src/store/feed/reducer.js
@@ -1,4 +1,4 @@
-import * as types from '../types';
+import * as types from 'kitsu/store/types';
 
 const INITIAL_STATE = {
   notifications: [],

--- a/src/store/media/actions.js
+++ b/src/store/media/actions.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import * as types from '../types';
-import { Kitsu, setToken } from '../../config/api';
+import * as types from 'kitsu/store/types';
+import { Kitsu } from 'kitsu/config/api';
 
 export const fetchMedia = (id, type) => async (dispatch, getState) => {
   dispatch({ type: types.FETCH_MEDIA });

--- a/src/store/media/reducer.js
+++ b/src/store/media/reducer.js
@@ -1,5 +1,4 @@
-import { REHYDRATE } from 'redux-persist/constants';
-import * as types from '../types';
+import * as types from 'kitsu/store/types';
 
 const INITIAL_STATE = {
   media: {},

--- a/src/store/profile/actions.js
+++ b/src/store/profile/actions.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import * as types from '../types';
-import { Kitsu, setToken } from '../../config/api';
+import * as types from 'kitsu/store/types';
+import { Kitsu } from 'kitsu/config/api';
 
 export const fetchProfile = id => async (dispatch) => {
   dispatch({ type: types.FETCH_USER });

--- a/src/store/profile/reducer.js
+++ b/src/store/profile/reducer.js
@@ -1,5 +1,5 @@
 import { REHYDRATE } from 'redux-persist/constants';
-import * as types from '../types';
+import * as types from 'kitsu/store/types';
 
 const INITIAL_STATE = {
   profile: {},

--- a/src/store/user/actions.js
+++ b/src/store/user/actions.js
@@ -1,6 +1,6 @@
-import * as types from '../types';
-import { Kitsu, setToken } from '../../config/api';
-import { loginUser } from '../auth/actions';
+import * as types from 'kitsu/store/types';
+import { Kitsu, setToken } from 'kitsu/config/api';
+import { loginUser } from 'kitsu/store/auth/actions';
 
 export const fetchCurrentUser = () => async (dispatch, getState) => {
   dispatch({ type: types.FETCH_CURRENT_USER });

--- a/src/store/user/reducer.js
+++ b/src/store/user/reducer.js
@@ -1,5 +1,5 @@
 import { REHYDRATE } from 'redux-persist/constants';
-import * as types from '../types';
+import * as types from 'kitsu/store/types';
 
 const INITIAL_STATE = {
   currentUser: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,6 +467,10 @@ babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
+babel-plugin-module-alias@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-module-alias/-/babel-plugin-module-alias-1.6.0.tgz#df7e3aaba3544f4c06a9d3314a26bbbff6d87b61"
+
 babel-plugin-react-transform@2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-react-transform/-/babel-plugin-react-transform-2.0.2.tgz#515bbfa996893981142d90b1f9b1635de2995109"
@@ -965,7 +969,7 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
-base-64@0.1.0, base-64@^0.1.0:
+base-64@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
 
@@ -1237,10 +1241,6 @@ clone-stats@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/clone-stats/-/clone-stats-0.0.1.tgz#b88f94a82cf38b8791d58046ea4029ad88ca99d1"
 
-clone@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.1.tgz#d217d1e961118e3ac9a4b8bba3285553bf647cdb"
-
 clone@^1.0.0, clone@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.2.tgz#260b7a99ebb1edfe247538175f783243cb19d149"
@@ -1323,10 +1323,6 @@ commoner@~0.10.3:
     private "^0.1.6"
     q "^1.1.2"
     recast "^0.11.17"
-
-component-emitter@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.0.tgz#ccd113a86388d06482d03de3fc7df98526ba8efe"
 
 component-emitter@~1.2.0:
   version "1.2.1"
@@ -1535,13 +1531,13 @@ dateformat@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
 
-debug@2, debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3:
+debug@2, debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
 
-debug@2.2.0, debug@~2.2.0:
+debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1903,31 +1899,38 @@ eslint-config-airbnb@^15.0.1:
   dependencies:
     eslint-config-airbnb-base "^11.2.0"
 
-eslint-import-resolver-node@^0.2.0:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+eslint-import-resolver-babel-module-alias@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-babel-module-alias/-/eslint-import-resolver-babel-module-alias-1.5.1.tgz#2b21245ce319132ecd91bfa6f44fc07edfd0367b"
   dependencies:
-    debug "^2.2.0"
+    find-babel-config "^1.0.0"
     object-assign "^4.0.1"
-    resolve "^1.1.6"
+    resolve "^1.1.7"
 
-eslint-module-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz#4422574cde66a9a7b099938ee4d508a199e0e3cc"
   dependencies:
-    debug "2.2.0"
+    debug "^2.6.8"
+    resolve "^1.2.0"
+
+eslint-module-utils@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+  dependencies:
+    debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz#37c801e0ada0e296cbdf20c3f393acb5b52af36b"
+eslint-plugin-import@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
-    debug "^2.2.0"
+    debug "^2.6.8"
     doctrine "1.5.0"
-    eslint-import-resolver-node "^0.2.0"
-    eslint-module-utils "^2.0.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.1.1"
     has "^1.0.1"
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
@@ -2254,6 +2257,13 @@ finalhandler@0.4.0:
     on-finished "~2.3.0"
     unpipe "~1.0.0"
 
+find-babel-config@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-babel-config/-/find-babel-config-1.1.0.tgz#acc01043a6749fec34429be6b64f542ebb5d6355"
+  dependencies:
+    json5 "^0.5.1"
+    path-exists "^3.0.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -2382,10 +2392,6 @@ generate-object-property@^1.1.0:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
-
-get-params@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/get-params/-/get-params-0.1.2.tgz#bae0dfaba588a0c60d7834c0d8dc2ff60eeef2fe"
 
 get-stdin@5.0.1:
   version "5.0.1"
@@ -3284,10 +3290,6 @@ js-yaml@^3.5.1, js-yaml@^3.7.0:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
-jsan@^3.1.0, jsan@^3.1.5:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/jsan/-/jsan-3.1.9.tgz#2705676c1058f0a7d9ac266ad036a5769cfa7c96"
-
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -3346,7 +3348,7 @@ json5@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
 
-json5@^0.5.0:
+json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
@@ -3436,10 +3438,6 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-
-linked-list@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/linked-list/-/linked-list-0.1.0.tgz#798b0ff97d1b92a4fd08480f55aea4e9d49d37bf"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -4813,17 +4811,6 @@ redux-action-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/redux-action-buffer/-/redux-action-buffer-1.0.1.tgz#4563f47e7c921c83cd0e8fefc713d3bba59e47b4"
 
-redux-devtools-extension@^2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz#e0f9a8e8dfca7c17be92c7124958a3b94eb2911d"
-
-redux-devtools-instrument@^1.3.3:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.2.tgz#5e91cfe402e790dae3fd2f0d235f7b7d84b09ffe"
-  dependencies:
-    lodash "^4.2.0"
-    symbol-observable "^1.0.2"
-
 redux-logger@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
@@ -4908,33 +4895,6 @@ regjsparser@^0.1.4:
   dependencies:
     jsesc "~0.5.0"
 
-remote-redux-devtools@^0.5.12:
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/remote-redux-devtools/-/remote-redux-devtools-0.5.12.tgz#42cb95dfa9e54c1d9671317c5e7bba41e68caec2"
-  dependencies:
-    jsan "^3.1.5"
-    querystring "^0.2.0"
-    redux-devtools-instrument "^1.3.3"
-    remotedev-utils "^0.1.1"
-    rn-host-detect "^1.0.1"
-    socketcluster-client "^5.3.1"
-
-remotedev-serialize@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/remotedev-serialize/-/remotedev-serialize-0.1.0.tgz#074768e98cb7aa806f45994eeb0c8af95120ee32"
-  dependencies:
-    jsan "^3.1.0"
-
-remotedev-utils@^0.1.1:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/remotedev-utils/-/remotedev-utils-0.1.4.tgz#643700819a943678073c75eb185e81d96620b348"
-  dependencies:
-    get-params "^0.1.2"
-    jsan "^3.1.5"
-    lodash "^4.0.0"
-    remotedev-serialize "^0.1.0"
-    shortid "^2.2.6"
-
 remove-trailing-separator@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.0.1.tgz#615ebb96af559552d4bf4057c8436d486ab63cc4"
@@ -5011,7 +4971,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.2:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -5053,10 +5013,6 @@ rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
 rimraf@~2.2.6:
   version "2.2.8"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
-
-rn-host-detect@^1.0.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/rn-host-detect/-/rn-host-detect-1.1.3.tgz#242d76e2fa485c48d751416e65b7cce596969e91"
 
 rndm@1.2.0:
   version "1.2.0"
@@ -5128,26 +5084,6 @@ sax@^1.2.1:
 sax@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
-
-sc-channel@~1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/sc-channel/-/sc-channel-1.0.6.tgz#b38bd47a993e78290fbc53467867f6b2a0a08639"
-  dependencies:
-    sc-emitter "1.x.x"
-
-sc-emitter@1.x.x, sc-emitter@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/sc-emitter/-/sc-emitter-1.1.0.tgz#ef119d4222f4c64f887b486964ef11116cdd0e75"
-  dependencies:
-    component-emitter "1.2.0"
-
-sc-errors@~1.3.0:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/sc-errors/-/sc-errors-1.3.3.tgz#c00bc4c766a970cc8d5937d08cd58e931d7dae05"
-
-sc-formatter@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/sc-formatter/-/sc-formatter-3.0.0.tgz#c91b1fe56c260abd5a6a2e6af98c724bc7998a38"
 
 "semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.3.0"
@@ -5236,10 +5172,6 @@ shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
 
-shortid@^2.2.6:
-  version "2.2.8"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.8.tgz#033b117d6a2e975804f6f0969dbe7d3d0b355131"
-
 signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -5293,20 +5225,6 @@ sntp@1.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
   dependencies:
     hoek "2.x.x"
-
-socketcluster-client@^5.3.1:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/socketcluster-client/-/socketcluster-client-5.5.2.tgz#9d4369e0e722ff7e55e5422c2d44f5afe1aff128"
-  dependencies:
-    base-64 "0.1.0"
-    clone "2.1.1"
-    linked-list "0.1.0"
-    querystring "0.2.0"
-    sc-channel "~1.0.6"
-    sc-emitter "~1.1.0"
-    sc-errors "~1.3.0"
-    sc-formatter "~3.0.0"
-    ws "3.0.0"
 
 socks-proxy-agent@2:
   version "2.0.0"
@@ -5896,13 +5814,6 @@ write@^0.2.1:
   resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
   dependencies:
     mkdirp "^0.5.1"
-
-ws@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-3.0.0.tgz#98ddb00056c8390cb751e7788788497f99103b6c"
-  dependencies:
-    safe-buffer "~5.0.1"
-    ultron "~1.1.0"
 
 ws@^1.1.0:
   version "1.1.4"


### PR DESCRIPTION
It gets incredibly unweildly managing relative paths of react
projects without an alias. We should be making heavy use of node-style
imports (index.js files) as well but this a first step to get us going
down a better path. The only time you should ever use a relative
import is to import a file from your own directory. Otherwise, alias.