### PR TITLE
fixing styles for empty states on user library

### DIFF
--- a/src/common/styles.js
+++ b/src/common/styles.js
@@ -5,6 +5,10 @@ export const commonStyles = StyleSheet.create({
   absoluteFill: {
     ...StyleSheet.absoluteFillObject,
   },
+  centerCenter: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   text: {
     fontFamily: 'OpenSans',
     fontSize: 12,
@@ -26,3 +30,8 @@ export const commonStyles = StyleSheet.create({
     color: colors.lightGrey,
   },
 });
+
+export const flattenCommon = (...styles) => {
+  const includedStyles = styles.map(style => commonStyles[style]);
+  return StyleSheet.flatten(includedStyles);
+};

--- a/src/screens/Profiles/UserLibrary/components/UserLibraryScreen/constants.js
+++ b/src/screens/Profiles/UserLibrary/components/UserLibraryScreen/constants.js
@@ -2,3 +2,4 @@ export const EMPTY_LIST_CONTAINER_HEIGHT = 125;
 export const POSTER_CARD_HEIGHT = 155;
 export const POSTER_CARD_WIDTH = 105;
 export const EMPTY_LIST_HEIGHT = 110;
+export const CARD_BORDER_RADIUS = 3;

--- a/src/screens/Profiles/UserLibrary/components/UserLibraryScreen/styles.js
+++ b/src/screens/Profiles/UserLibrary/components/UserLibraryScreen/styles.js
@@ -1,39 +1,40 @@
 import { StyleSheet } from 'react-native';
 import * as colors from 'kitsu/constants/colors';
+import { flattenCommon } from 'kitsu/common/styles';
 import * as constants from './constants';
+
+const emptyBorderStyle = {
+  borderColor: 'rgba(255,255,255,0.1)',
+  borderRadius: constants.CARD_BORDER_RADIUS,
+  borderStyle: 'dashed',
+  borderWidth: 2,
+};
 
 export const styles = StyleSheet.create({
   browseText: {
     paddingBottom: 10,
   },
   browseButton: {
+    ...flattenCommon('centerCenter'),
     width: 125,
     height: 30,
     borderRadius: 4,
     backgroundColor: colors.green,
-    alignItems: 'center',
-    justifyContent: 'center',
   },
   container: {
+    ...flattenCommon('centerCenter'),
     flex: 1,
-    alignItems: 'center',
     backgroundColor: colors.darkPurple,
-    justifyContent: 'center',
   },
   emptyList: {
-    alignItems: 'center',
-    borderStyle: 'dashed',
-    borderWidth: 2,
-    borderColor: colors.lightGrey,
+    ...flattenCommon('centerCenter'),
+    ...emptyBorderStyle,
     flex: 1,
     height: constants.EMPTY_LIST_HEIGHT,
-    justifyContent: 'center',
     marginHorizontal: 15,
   },
   emptyPosterImageCard: {
-    borderColor: colors.lightGrey,
-    borderStyle: 'dashed',
-    borderWidth: 2,
+    ...emptyBorderStyle,
     height: constants.POSTER_CARD_HEIGHT,
     marginHorizontal: 4,
     width: constants.POSTER_CARD_WIDTH,
@@ -47,7 +48,7 @@ export const styles = StyleSheet.create({
     width: constants.POSTER_CARD_WIDTH,
     height: constants.POSTER_CARD_HEIGHT,
     marginBottom: 2,
-    borderRadius: 3,
+    borderRadius: constants.CARD_BORDER_RADIUS,
   },
   posterImageCardFirstChild: {
     marginLeft: 12,


### PR DESCRIPTION
Adding a `flattenCommon` export to `kitsu/common/styles` which makes it easier to include common styles into self-defined styles.