### PR TITLE
adding simple header component

### DIFF
--- a/src/components/SimpleHeader/component.js
+++ b/src/components/SimpleHeader/component.js
@@ -3,15 +3,21 @@ import * as PropTypes from 'prop-types';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { styles } from './styles';
 
+const noop = () => {};
+
 export const SimpleHeader = (props) => {
   const LeftWrapper = props.leftAction ? TouchableOpacity : View;
   const TitleWrapper = props.titleAction ? TouchableOpacity : View;
   const RightWrapper = props.rightAction ? TouchableOpacity : View;
 
+  const leftAction = props.leftAction ? () => props.leftAction() : noop;
+  const titleAction = props.titleAction ? () => props.leftAction() : noop;
+  const rightAction = props.rightAction ? () => props.leftAction() : noop;
+
   return (
     <View style={styles.headerContainer}>
       {props.titleContent &&
-        <TitleWrapper style={styles.titleContainer} onPress={props.titleAction}>
+        <TitleWrapper style={styles.titleContainer} onPress={titleAction}>
           {typeof props.titleContent === 'string' ?
             <Text style={styles.headerTitleText}>{props.titleContent}</Text> :
             props.titleContent
@@ -20,7 +26,7 @@ export const SimpleHeader = (props) => {
       }
 
       {props.leftContent &&
-        <LeftWrapper style={styles.leftContainer} onPress={props.leftAction}>
+        <LeftWrapper style={styles.leftContainer} onPress={leftAction}>
           {typeof props.leftContent === 'string' ?
             <Text style={styles.headerItemText}>{props.leftContent}</Text> :
             props.leftContent
@@ -29,7 +35,7 @@ export const SimpleHeader = (props) => {
       }
 
       {props.rightContent &&
-        <RightWrapper style={styles.rightContainer} onPress={props.rightAction}>
+        <RightWrapper style={styles.rightContainer} onPress={rightAction}>
           {typeof props.rightContent === 'string' ?
             <Text style={styles.headerItemText}>{props.rightContent}</Text> :
             props.rightContent

--- a/src/components/SimpleHeader/component.js
+++ b/src/components/SimpleHeader/component.js
@@ -3,16 +3,14 @@ import * as PropTypes from 'prop-types';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { styles } from './styles';
 
-const noop = () => {};
-
 export const SimpleHeader = (props) => {
   const LeftWrapper = props.leftAction ? TouchableOpacity : View;
   const TitleWrapper = props.titleAction ? TouchableOpacity : View;
   const RightWrapper = props.rightAction ? TouchableOpacity : View;
 
-  const leftAction = props.leftAction ? () => props.leftAction() : noop;
-  const titleAction = props.titleAction ? () => props.leftAction() : noop;
-  const rightAction = props.rightAction ? () => props.leftAction() : noop;
+  const leftAction = props.leftAction ? () => props.leftAction() : null;
+  const titleAction = props.titleAction ? () => props.leftAction() : null;
+  const rightAction = props.rightAction ? () => props.leftAction() : null;
 
   return (
     <View style={styles.headerContainer}>

--- a/src/components/SimpleHeader/component.js
+++ b/src/components/SimpleHeader/component.js
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as PropTypes from 'prop-types';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { styles } from './styles';
+
+export const SimpleHeader = (props) => {
+  const LeftWrapper = props.leftAction ? TouchableOpacity : View;
+  const TitleWrapper = props.titleAction ? TouchableOpacity : View;
+  const RightWrapper = props.rightAction ? TouchableOpacity : View;
+
+  return (
+    <View style={styles.headerContainer}>
+      {props.titleContent &&
+        <TitleWrapper style={styles.titleContainer} onPress={props.titleAction}>
+          {typeof props.titleContent === 'string' ?
+            <Text style={styles.headerTitleText}>{props.titleContent}</Text> :
+            props.titleContent
+          }
+        </TitleWrapper>
+      }
+
+      {props.leftContent &&
+        <LeftWrapper style={styles.leftContainer} onPress={props.leftAction}>
+          {typeof props.leftContent === 'string' ?
+            <Text style={styles.headerItemText}>{props.leftContent}</Text> :
+            props.leftContent
+          }
+        </LeftWrapper>
+      }
+
+      {props.rightContent &&
+        <RightWrapper style={styles.rightContainer} onPress={props.rightAction}>
+          {typeof props.rightContent === 'string' ?
+            <Text style={styles.headerItemText}>{props.rightContent}</Text> :
+            props.rightContent
+          }
+        </RightWrapper>
+      }
+    </View>
+  );
+};
+
+SimpleHeader.propTypes = {
+  leftAction: PropTypes.any,
+  leftContent: PropTypes.any,
+  rightAction: PropTypes.any,
+  rightContent: PropTypes.any,
+  titleAction: PropTypes.any,
+  titleContent: PropTypes.any,
+};
+
+SimpleHeader.defaultProps = {
+  leftAction: null,
+  leftContent: null,
+  rightAction: null,
+  rightContent: null,
+  titleAction: null,
+  titleContent: null,
+};

--- a/src/components/SimpleHeader/index.js
+++ b/src/components/SimpleHeader/index.js
@@ -1,0 +1,1 @@
+export * from './component';

--- a/src/components/SimpleHeader/styles.js
+++ b/src/components/SimpleHeader/styles.js
@@ -1,0 +1,40 @@
+import { StyleSheet } from 'react-native';
+import { flattenCommon } from 'kitsu/common/styles';
+import * as colors from 'kitsu/constants/colors';
+
+export const styles = StyleSheet.create({
+  headerContainer: {
+    alignItems: 'flex-end',
+    backgroundColor: colors.darkPurple,
+    flexDirection: 'row',
+    height: 60,
+  },
+  headerItemText: {
+    ...flattenCommon('text'),
+    color: colors.lightGrey,
+    fontSize: 16,
+  },
+  headerTitleText: {
+    ...flattenCommon('text', 'textHeavy'),
+    color: colors.white,
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  leftContainer: {
+    marginRight: 'auto',
+    paddingLeft: 10,
+    paddingBottom: 8,
+  },
+  titleContainer: {
+    position: 'absolute',
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    paddingBottom: 8,
+  },
+  rightContainer: {
+    marginLeft: 'auto',
+    paddingRight: 10,
+    paddingBottom: 8,
+  },
+});


### PR DESCRIPTION
Simple header component

I might eventually refactor the ProfileHeader to just use this component. If building a screen with a header that has a left/middle/right content, use this component

```
<SimpleHeader
  leftContent="Cancel"
  leftAction={this.props.navigation.goBack}
  titleContent="Edit Entry"
  rightContent="Save"
  rightAction={this.saveLibraryEntry}
/>
```

Each content can also just be a renderable...