### PR TITLE
Fixes fonts & spacing issues in search screen

### DIFF
--- a/src/components/ContentList/styles.js
+++ b/src/components/ContentList/styles.js
@@ -22,7 +22,7 @@ export const styles = StyleSheet.create({
   },
   contentListHeaderText: {
     fontSize: 12,
-    fontWeight: 'bold',
+    fontWeight: '400',
     fontFamily: 'OpenSans',
     color: '#392F39',
   },
@@ -33,12 +33,12 @@ export const styles = StyleSheet.create({
   },
   contentListActionLinkText: {
     fontSize: 12,
-    fontWeight: 'bold',
+    fontWeight: '400',
     fontFamily: 'OpenSans',
     color: '#392F39',
   },
   linkIcon: {
-    fontSize: 10,
+    fontSize: 12,
     fontWeight: '200',
     fontFamily: 'OpenSans',
     paddingLeft: 4,

--- a/src/components/MediaCard/styles.js
+++ b/src/components/MediaCard/styles.js
@@ -9,7 +9,7 @@ export const styles = StyleSheet.create({
     fontSize: 10,
   },
   posterImageContainer: {
-    marginHorizontal: 4,
+    marginRight: 4,
   },
   posterImageCard: {
     backgroundColor: colors.lightPurple,

--- a/src/components/SearchBox/styles.js
+++ b/src/components/SearchBox/styles.js
@@ -8,7 +8,7 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: colors.white,
     borderRadius: 3,
-    height: 40,
+    height: 29,
   },
   searchIcon: {
     position: 'absolute',


### PR DESCRIPTION
<img width="449" alt="iphone 6 - ios 11 0 2017-10-21 16-52-45" src="https://user-images.githubusercontent.com/1650995/31851283-4c514da4-b680-11e7-98d7-888d7006b1e1.png">

Trello Card Link: https://trello.com/c/stPAKJmW/109-sizing-and-spacing-does-not-match-design
