### PR TITLE
Fixing import issue with URL.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "redux-persist": "^4.8.0",
     "redux-thunk": "^2.2.0",
     "tcomb-form-native": "^0.6.8",
-    "url": "^0.11.0"
+    "url-parse": "^1.2.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^3.2.12",

--- a/src/screens/Feed/index.js
+++ b/src/screens/Feed/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { RefreshControl, StatusBar, View } from 'react-native';
+import { connect } from 'react-redux';
+import { KeyboardAwareFlatList } from 'react-native-keyboard-aware-scroll-view';
 import PropTypes from 'prop-types';
 import { unescape } from 'lodash';
-import { KeyboardAwareFlatList } from 'react-native-keyboard-aware-scroll-view';
-import { connect } from 'react-redux';
+import URL from 'url-parse';
 
 import { Kitsu } from 'kitsu/config/api';
 import { listBackPurple } from 'kitsu/constants/colors';
@@ -80,8 +81,8 @@ class Feed extends React.PureComponent {
       });
 
       // I need to read the cursor value out of the 'next' link in the result.
-      const url = new URL(result.links.next);
-      this.cursor = url.searchParams.get('page[cursor]');
+      const url = new URL(result.links.next, true);
+      this.cursor = url.query['page[cursor]'];
 
       // Discard the activity groups and activities for now, flattening to
       // just the subject of the activity.

--- a/yarn.lock
+++ b/yarn.lock
@@ -7382,7 +7382,7 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requires-port@1.0.x:
+requires-port@1.0.x, requires-port@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
@@ -8296,6 +8296,13 @@ url-parse@^1.1.9:
   dependencies:
     querystringify "~1.0.0"
     requires-port "1.0.x"
+
+url-parse@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.2.0.tgz#3a19e8aaa6d023ddd27dcc44cb4fc8f7fec23986"
+  dependencies:
+    querystringify "~1.0.0"
+    requires-port "~1.0.0"
 
 url@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
It was available because I was debugging so it came from Chrome Debugger Tools, but when I ran without debugging the app crashed. Also removed the `url` module because it doesn't seem to be used anywhere in the app.