### PR TITLE
Search page improvements

### DIFF
--- a/src/components/ContentList/ContentListHeader.js
+++ b/src/components/ContentList/ContentListHeader.js
@@ -4,20 +4,25 @@ import PropTypes from 'prop-types';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { styles } from './styles';
 
-export const ContentListHeader = ({ title, dark, ...props }) => (
+export const ContentListHeader = ({ title, dark, showViewAll, ...props }) => (
   <View style={styles.contentListHeaderContainer}>
     <Text style={[styles.contentListHeaderText, dark ? styles.lightText : '']}>{title}</Text>
-    <TouchableOpacity style={styles.contentListActionLink} {...props}>
+    {showViewAll && <TouchableOpacity style={styles.contentListActionLink} {...props}>
       <Text style={[styles.contentListActionLinkText, dark ? styles.lightText : '']}>View All</Text>
       <Icon
         name="chevron-right"
         style={[styles.linkIcon, dark ? styles.iconLight : styles.iconDark]}
       />
-    </TouchableOpacity>
+    </TouchableOpacity>}
   </View>
 );
 
 ContentListHeader.propTypes = {
   title: PropTypes.string.isRequired,
   dark: PropTypes.bool.isRequired,
+  showViewAll: PropTypes.bool,
+};
+
+ContentListHeader.defaultProps = {
+  showViewAll: true,
 };

--- a/src/components/ContentList/ItemRenderer.js
+++ b/src/components/ContentList/ItemRenderer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Text, TouchableOpacity, Image } from 'react-native';
 import { MediaCard } from 'kitsu/components/MediaCard';
+import { View } from 'react-native';
 import { styles } from './styles';
 
 const MEDIA_CARD_DIMENSIONS = { width: 100, height: 150 };
@@ -16,5 +17,6 @@ export const ItemRenderer = ({ item, type, ...props }) => {
   if (type === 'static') {
     return <LandscapeMediaCard {...item} />;
   }
-  return <MediaCard cardDimensions={MEDIA_CARD_DIMENSIONS} mediaData={item} {...props} />;
+
+  return <MediaCard cardDimensions={MEDIA_CARD_DIMENSIONS} mediaData={item} loading={type === 'loading'} {...props} />;
 };

--- a/src/components/ContentList/ItemRenderer.js
+++ b/src/components/ContentList/ItemRenderer.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Text, TouchableOpacity, Image } from 'react-native';
 import { MediaCard } from 'kitsu/components/MediaCard';
-import { View } from 'react-native';
 import { styles } from './styles';
 
 const MEDIA_CARD_DIMENSIONS = { width: 100, height: 150 };

--- a/src/components/ContentList/component.js
+++ b/src/components/ContentList/component.js
@@ -13,6 +13,7 @@ export const ContentList = ({ title, data, onPress, dark = false, ...props }) =>
       horizontal
       removeClippedSubviews={false}
       data={data}
+      ListHeaderComponent={() => <View style={{ width: 10 }} />}
       renderItem={({ item }) => <ItemRenderer item={item} {...props} />}
     />
   </View>

--- a/src/components/ContentList/component.js
+++ b/src/components/ContentList/component.js
@@ -5,10 +5,10 @@ import { ContentListHeader } from './ContentListHeader';
 import { ItemRenderer } from './ItemRenderer';
 import { styles } from './styles';
 
-export const ContentList = ({ title, data, onPress, dark = false, ...props }) => (
+export const ContentList = ({ title, data, onPress, dark = false, showViewAll = true, ...props }) => (
   // console.log('data is', title, data);
   <View style={[styles.contentListContainer, dark ? styles.darkBg : styles.lightBg]}>
-    <ContentListHeader dark={dark} title={title} onPress={onPress} />
+    <ContentListHeader dark={dark} title={title} onPress={onPress} showViewAll={showViewAll} />
     <FlatList
       horizontal
       removeClippedSubviews={false}
@@ -24,9 +24,11 @@ ContentList.propTypes = {
   data: PropTypes.array,
   onPress: PropTypes.func.isRequired,
   dark: PropTypes.bool,
+  showViewAll: PropTypes.bool,
 };
 
 ContentList.defaultProps = {
   data: [],
   dark: false,
+  showViewAll: true,
 };

--- a/src/components/ContentList/styles.js
+++ b/src/components/ContentList/styles.js
@@ -3,8 +3,7 @@ import * as colors from 'kitsu/constants/colors';
 
 export const styles = StyleSheet.create({
   contentListContainer: {
-    paddingTop: 10,
-    paddingBottom: 10,
+    paddingVertical: 10,
   },
   darkBg: {
     backgroundColor: colors.lightPurple,
@@ -20,8 +19,7 @@ export const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 10,
-    paddingLeft: 10,
-    paddingRight: 10,
+    paddingHorizontal: 10,
   },
   contentListHeaderText: {
     fontSize: 12,

--- a/src/components/ContentList/styles.js
+++ b/src/components/ContentList/styles.js
@@ -3,7 +3,8 @@ import * as colors from 'kitsu/constants/colors';
 
 export const styles = StyleSheet.create({
   contentListContainer: {
-    padding: 10,
+    paddingTop: 10,
+    paddingBottom: 10,
   },
   darkBg: {
     backgroundColor: colors.lightPurple,
@@ -19,6 +20,8 @@ export const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
     marginBottom: 10,
+    paddingLeft: 10,
+    paddingRight: 10,
   },
   contentListHeaderText: {
     fontSize: 12,

--- a/src/components/MediaCard/component.js
+++ b/src/components/MediaCard/component.js
@@ -28,7 +28,7 @@ export const MediaCard = ({
   };
 
   return (
-    <TouchableOpacity onPress={!loading && onPress}>
+    <TouchableOpacity onPress={onPress} disabled={loading}>
       <View style={[styles.posterImageContainer, { width: cardDimensions.width }, style]}>
         {mediaData.posterImage ? (
           <ProgressiveImage
@@ -79,7 +79,7 @@ MediaCard.propTypes = {
   ratingTwenty: PropTypes.number,
   ratingSystem: PropTypes.string,
   style: ViewPropTypes.style,
-  loading: PropTypes.boolean,
+  loading: PropTypes.bool,
 };
 
 MediaCard.defaultProps = {

--- a/src/components/MediaCard/component.js
+++ b/src/components/MediaCard/component.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, TouchableOpacity, View, ViewPropTypes } from 'react-native';
+import { Text, TouchableOpacity, View, ViewPropTypes, ActivityIndicator } from 'react-native';
 import { PropTypes } from 'prop-types';
 import { ProgressBar } from 'kitsu/components/ProgressBar';
 import { ProgressiveImage } from 'kitsu/components/ProgressiveImage';
@@ -16,12 +16,15 @@ export const MediaCard = ({
   ratingTwenty,
   ratingSystem,
   style,
+  loading,
 }) => {
   const onPress = () => {
-    navigate('MediaPages', {
-      mediaId: mediaData.id,
-      mediaType: mediaData.type,
-    });
+    if (mediaData.id && mediaData.type) {
+      navigate('MediaPages', {
+        mediaId: mediaData.id,
+        mediaType: mediaData.type,
+      });
+    }
   };
 
   return (
@@ -54,6 +57,13 @@ export const MediaCard = ({
             style={styles.rating}
           />
         )}
+
+        {loading &&
+          <View style={styles.loading}>
+            <ActivityIndicator color={'rgba(255,255,255,0.6)'} />
+          </View>
+        }
+
       </View>
     </TouchableOpacity>
   );
@@ -69,6 +79,7 @@ MediaCard.propTypes = {
   ratingTwenty: PropTypes.number,
   ratingSystem: PropTypes.string,
   style: ViewPropTypes.style,
+  loading: PropTypes.boolean,
 };
 
 MediaCard.defaultProps = {
@@ -78,4 +89,5 @@ MediaCard.defaultProps = {
   ratingTwenty: undefined,
   ratingSystem: 'simple',
   style: null,
+  loading: false,
 };

--- a/src/components/MediaCard/component.js
+++ b/src/components/MediaCard/component.js
@@ -28,7 +28,7 @@ export const MediaCard = ({
   };
 
   return (
-    <TouchableOpacity onPress={onPress}>
+    <TouchableOpacity onPress={!loading && onPress}>
       <View style={[styles.posterImageContainer, { width: cardDimensions.width }, style]}>
         {mediaData.posterImage ? (
           <ProgressiveImage

--- a/src/components/MediaCard/styles.js
+++ b/src/components/MediaCard/styles.js
@@ -22,4 +22,13 @@ export const styles = StyleSheet.create({
   rating: {
     marginTop: 2,
   },
+  loading: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });

--- a/src/routes/search.js
+++ b/src/routes/search.js
@@ -4,6 +4,7 @@ import { StackNavigator } from 'react-navigation';
 import SearchScreen from 'kitsu/screens/Search/SearchScreen';
 import SearchCategory from 'kitsu/screens/Search/SearchCategory';
 import SearchResults from 'kitsu/screens/Search/SearchResults';
+import SeasonScreen from 'kitsu/screens/Search/SeasonScreen';
 import MediaPages from 'kitsu/screens/Profiles/MediaPages';
 import ProfilePages from 'kitsu/screens/Profiles/ProfilePages';
 import search from 'kitsu/assets/img/tabbar_icons/search.png';
@@ -19,6 +20,9 @@ const SearchStack = StackNavigator(
     },
     SearchResults: {
       screen: SearchResults,
+    },
+    SeasonScreen: {
+      screen: SeasonScreen,
     },
     MediaPages: {
       screen: MediaPages,

--- a/src/screens/Search/Lists/TopsList/index.js
+++ b/src/screens/Search/Lists/TopsList/index.js
@@ -81,6 +81,10 @@ class TopsList extends PureComponent {
     return data;
   }
 
+  isEmpty(array) {
+    return (array === undefined || array.length === 0);
+  }
+
   handleViewAllPress = (title, type) => {
     this.props.navigation.navigate('SearchResults', {
       label: title,
@@ -189,11 +193,15 @@ class TopsList extends PureComponent {
       },
     ];
 
+    // Loading data is just an array of strings
+    // We don't care about how it's represented
+    const loadingData = Array(5).fill(0).map(i => i.toString());
+
     const listData = [
       {
         title: `Top Airing ${activeLabel}`,
-        data: data.topAiring,
-        type: 'topAiring',
+        data: this.isEmpty(data.topAiring) ? loadingData : data.topAiring,
+        type: this.isEmpty(data.topAiring) ? 'loading' : 'topAiring',
       },
       {
         title: `${activeLabel} By Streaming`,
@@ -203,8 +211,8 @@ class TopsList extends PureComponent {
       },
       {
         title: `Top Upcoming ${activeLabel}`,
-        data: data.topUpcoming,
-        type: 'topUpcoming',
+        data: this.isEmpty(data.topUpcoming) ? loadingData : data.topUpcoming,
+        type: this.isEmpty(data.topUpcoming) ? 'loading' : 'topUpcoming',
       },
       {
         title: `${activeLabel} By Seasons`,
@@ -214,8 +222,8 @@ class TopsList extends PureComponent {
       },
       {
         title: `Highest Rated ${activeLabel}`,
-        data: data.highest,
-        type: 'highest',
+        data: this.isEmpty(data.highest) ? loadingData : data.highest,
+        type: this.isEmpty(data.highest) ? 'loading' : 'highest',
       },
       {
         title: `${activeLabel} By Categeory`,
@@ -225,8 +233,8 @@ class TopsList extends PureComponent {
       },
       {
         title: `Most Popular ${activeLabel}`,
-        data: data.popular,
-        type: 'popular',
+        data: this.isEmpty(data.popular) ? loadingData : data.popular,
+        type: this.isEmpty(data.popular) ? 'loading' : 'popular',
       },
     ];
     return (

--- a/src/screens/Search/Lists/TopsList/index.js
+++ b/src/screens/Search/Lists/TopsList/index.js
@@ -85,7 +85,13 @@ class TopsList extends PureComponent {
     return (array === undefined || array.length === 0);
   }
 
-  handleViewAllPress = (title, type) => {
+  handleViewAllPress = (title, type, action) => {
+    if (action === 'season') {
+      this.props.navigation.navigate('SeasonScreen', {
+        label: 'Seasons',
+      });
+      return;
+    }
     this.props.navigation.navigate('SearchResults', {
       label: title,
       default: type,
@@ -93,37 +99,8 @@ class TopsList extends PureComponent {
     });
   };
 
-  render() {
-    const { active, navigation: { navigate } } = this.props;
-    const data = this.props[active] || {};
-    const activeLabel = upperFirst(active);
-
-    const streamingServices = [
-      {
-        name: 'netflix',
-        image: require('kitsu/assets/img/streaming-services/netflix.png'),
-      },
-      {
-        name: 'hulu',
-        image: require('kitsu/assets/img/streaming-services/hulu.png'),
-      },
-      {
-        name: 'crunchyroll',
-        image: require('kitsu/assets/img/streaming-services/crunchyroll.png'),
-      },
-      {
-        name: 'funimation',
-        image: require('kitsu/assets/img/streaming-services/funimation.png'),
-      },
-      {
-        name: 'viewster',
-        image: require('kitsu/assets/img/streaming-services/viewster.png'),
-      },
-    ];
-
-    const seasonsData = this.getSeasonsData();
-
-    const animeData = [
+  getAnimeCategories() {
+    return [
       {
         title: 'Action',
         image: require('kitsu/assets/img/anime-categories/Action.png'),
@@ -157,8 +134,10 @@ class TopsList extends PureComponent {
         image: require('kitsu/assets/img/anime-categories/Sports.png'),
       },
     ];
+  }
 
-    const mangaData = [
+  getMangaCategories() {
+    return [
       {
         title: 'Action',
         image: require('kitsu/assets/img/manga-categories/Action.png'),
@@ -192,51 +171,118 @@ class TopsList extends PureComponent {
         image: require('kitsu/assets/img/manga-categories/Sports.png'),
       },
     ];
+  }
+
+  /**
+   * Get the list data for the given media type.
+   * @param  {String} type `Anime` or `Manga`.
+   * @param  {Dictionary} data The props data.
+   * @return {Array}  An array for the given media type.
+   */
+  getListData(type, data) {
+    const seasons = this.getSeasonsData();
+    const seasonsData = {
+      title: `${type} By Seasons`,
+      data: seasons,
+      dark: true,
+      type: 'static',
+      action: 'season',
+    };
+
+    const streamingServices = [
+      {
+        name: 'netflix',
+        image: require('kitsu/assets/img/streaming-services/netflix.png'),
+      },
+      {
+        name: 'hulu',
+        image: require('kitsu/assets/img/streaming-services/hulu.png'),
+      },
+      {
+        name: 'crunchyroll',
+        image: require('kitsu/assets/img/streaming-services/crunchyroll.png'),
+      },
+      {
+        name: 'funimation',
+        image: require('kitsu/assets/img/streaming-services/funimation.png'),
+      },
+      {
+        name: 'viewster',
+        image: require('kitsu/assets/img/streaming-services/viewster.png'),
+      },
+    ];
+    const streamingData = {
+      title: `${type} By Streaming`,
+      dark: true,
+      data: streamingServices,
+      type: 'static',
+      showViewAll: false,
+    };
+
+    // Because react doesn't allow dynamic image loading, we have to do it this way :(
+    const categoryData = {
+      title: `${type} By Categeory`,
+      data: (type === 'Anime') ? this.getAnimeCategories() : this.getMangaCategories(),
+      dark: true,
+      type: 'static',
+      showViewAll: false,
+    };
 
     // Loading data is just an array of strings
     // We don't care about how it's represented
     const loadingData = Array(5).fill(0).map(i => i.toString());
 
-    const listData = [
-      {
-        title: `Top Airing ${activeLabel}`,
-        data: this.isEmpty(data.topAiring) ? loadingData : data.topAiring,
-        type: this.isEmpty(data.topAiring) ? 'loading' : 'topAiring',
-      },
-      {
-        title: `${activeLabel} By Streaming`,
-        dark: true,
-        data: streamingServices,
-        type: 'static',
-      },
-      {
-        title: `Top Upcoming ${activeLabel}`,
-        data: this.isEmpty(data.topUpcoming) ? loadingData : data.topUpcoming,
-        type: this.isEmpty(data.topUpcoming) ? 'loading' : 'topUpcoming',
-      },
-      {
-        title: `${activeLabel} By Seasons`,
-        data: seasonsData,
-        dark: true,
-        type: 'static',
-      },
-      {
-        title: `Highest Rated ${activeLabel}`,
-        data: this.isEmpty(data.highest) ? loadingData : data.highest,
-        type: this.isEmpty(data.highest) ? 'loading' : 'highest',
-      },
-      {
-        title: `${activeLabel} By Categeory`,
-        data: active === 'anime' ? animeData : mangaData,
-        dark: true,
-        type: 'static',
-      },
-      {
-        title: `Most Popular ${activeLabel}`,
-        data: this.isEmpty(data.popular) ? loadingData : data.popular,
-        type: this.isEmpty(data.popular) ? 'loading' : 'popular',
-      },
+    const topData = {
+      title: (type === 'Anime') ? `Top Airing ${type}` : `Top Publishing ${type}`,
+      data: this.isEmpty(data.topAiring) ? loadingData : data.topAiring,
+      type: this.isEmpty(data.topAiring) ? 'loading' : 'topAiring',
+    };
+
+    const upcomingData = {
+      title: `Top Upcoming ${type}`,
+      data: this.isEmpty(data.topUpcoming) ? loadingData : data.topUpcoming,
+      type: this.isEmpty(data.topUpcoming) ? 'loading' : 'topUpcoming',
+    };
+
+    const highestRatedData = {
+      title: `Highest Rated ${type}`,
+      data: this.isEmpty(data.highest) ? loadingData : data.highest,
+      type: this.isEmpty(data.highest) ? 'loading' : 'highest',
+    };
+
+    const mostPopularData = {
+      title: `Most Popular ${type}`,
+      data: this.isEmpty(data.popular) ? loadingData : data.popular,
+      type: this.isEmpty(data.popular) ? 'loading' : 'popular',
+    };
+
+    const animeData = [
+      topData,
+      streamingData,
+      upcomingData,
+      seasonsData,
+      highestRatedData,
+      categoryData,
+      mostPopularData,
     ];
+
+    const mangaData = [
+      topData,
+      highestRatedData,
+      categoryData,
+      mostPopularData,
+    ];
+
+    return (type === 'Anime') ? animeData : mangaData;
+  }
+
+  render() {
+    const { active, navigation: { navigate } } = this.props;
+    const data = this.props[active] || {};
+    const activeLabel = upperFirst(active);
+
+    const listData = this.getListData(activeLabel, data);
+
     return (
       <ScrollView style={styles.scrollContainer}>
         {listData.map(listItem => (
@@ -244,7 +290,7 @@ class TopsList extends PureComponent {
             {...listItem}
             key={listItem.name || listItem.title}
             navigate={navigate}
-            onPress={() => this.handleViewAllPress(listItem.title, listItem.type)}
+            onPress={() => this.handleViewAllPress(listItem.title, listItem.type, listItem.action)}
           />
         ))}
       </ScrollView>

--- a/src/screens/Search/Lists/TopsList/index.js
+++ b/src/screens/Search/Lists/TopsList/index.js
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import { ScrollView } from 'react-native';
 import { connect } from 'react-redux';
-import { upperFirst } from 'lodash';
+import { upperFirst, isEmpty } from 'lodash';
 import { getDefaults, getCategories } from 'kitsu/store/anime/actions';
 import { ContentList } from 'kitsu/components/ContentList';
 import { styles } from './styles';
@@ -80,24 +80,6 @@ class TopsList extends PureComponent {
 
     return data;
   }
-
-  isEmpty(array) {
-    return (array === undefined || array.length === 0);
-  }
-
-  handleViewAllPress = (title, type, action) => {
-    if (action === 'season') {
-      this.props.navigation.navigate('SeasonScreen', {
-        label: 'Seasons',
-      });
-      return;
-    }
-    this.props.navigation.navigate('SearchResults', {
-      label: title,
-      default: type,
-      active: this.props.active,
-    });
-  };
 
   getAnimeCategories() {
     return [
@@ -234,26 +216,26 @@ class TopsList extends PureComponent {
 
     const topData = {
       title: (type === 'Anime') ? `Top Airing ${type}` : `Top Publishing ${type}`,
-      data: this.isEmpty(data.topAiring) ? loadingData : data.topAiring,
-      type: this.isEmpty(data.topAiring) ? 'loading' : 'topAiring',
+      data: isEmpty(data.topAiring) ? loadingData : data.topAiring,
+      type: isEmpty(data.topAiring) ? 'loading' : 'topAiring',
     };
 
     const upcomingData = {
       title: `Top Upcoming ${type}`,
-      data: this.isEmpty(data.topUpcoming) ? loadingData : data.topUpcoming,
-      type: this.isEmpty(data.topUpcoming) ? 'loading' : 'topUpcoming',
+      data: isEmpty(data.topUpcoming) ? loadingData : data.topUpcoming,
+      type: isEmpty(data.topUpcoming) ? 'loading' : 'topUpcoming',
     };
 
     const highestRatedData = {
       title: `Highest Rated ${type}`,
-      data: this.isEmpty(data.highest) ? loadingData : data.highest,
-      type: this.isEmpty(data.highest) ? 'loading' : 'highest',
+      data: isEmpty(data.highest) ? loadingData : data.highest,
+      type: isEmpty(data.highest) ? 'loading' : 'highest',
     };
 
     const mostPopularData = {
       title: `Most Popular ${type}`,
-      data: this.isEmpty(data.popular) ? loadingData : data.popular,
-      type: this.isEmpty(data.popular) ? 'loading' : 'popular',
+      data: isEmpty(data.popular) ? loadingData : data.popular,
+      type: isEmpty(data.popular) ? 'loading' : 'popular',
     };
 
     const animeData = [
@@ -275,6 +257,20 @@ class TopsList extends PureComponent {
 
     return (type === 'Anime') ? animeData : mangaData;
   }
+
+  handleViewAllPress = (title, type, action) => {
+    if (action === 'season') {
+      this.props.navigation.navigate('SeasonScreen', {
+        label: 'Seasons',
+      });
+      return;
+    }
+    this.props.navigation.navigate('SearchResults', {
+      label: title,
+      default: type,
+      active: this.props.active,
+    });
+  };
 
   render() {
     const { active, navigation: { navigate } } = this.props;

--- a/src/screens/Search/Lists/TopsList/index.js
+++ b/src/screens/Search/Lists/TopsList/index.js
@@ -16,6 +16,71 @@ class TopsList extends PureComponent {
     this.props.getDefaults('topUpcoming', active);
   }
 
+  /**
+   * Get the season corresponding to the given month
+   * @param  {Int} month The integer month (1 - 12)
+   * @return {String} The season (Winter, Spring, Summer, Fall).
+   */
+  getSeason(month) {
+    // Make sure month is an integer in 1 - 12
+    const normalised = ((month - 1) % 12) + 1;
+    if (normalised >= 1 && normalised <= 3) {
+      return 'Winter';
+    } else if (normalised >= 4 && normalised <= 6) {
+      return 'Spring';
+    } else if (normalised >= 7 && normalised <= 9) {
+      return 'Summer';
+    }
+    return 'Fall';
+  }
+
+  getSeasonsData() {
+    // This will only show the past 2 year worth of seasons
+    // The rest should be viewable in 'View All'
+    const curMonth = new Date().getMonth() + 1;
+    const curYear = new Date().getFullYear();
+    const minYear = curYear - 2;
+    const data = [];
+
+    const seasons = ['Fall', 'Summer', 'Spring', 'Winter'];
+
+    // Get the data object for the given season and year
+    const getData = (season, year) => {
+      const images = {
+        Winter: require('kitsu/assets/img/seasons/Winter.png'),
+        Spring: require('kitsu/assets/img/seasons/Spring.png'),
+        Summer: require('kitsu/assets/img/seasons/Summer.png'),
+        Fall: require('kitsu/assets/img/seasons/Fall.png'),
+      };
+
+      return {
+        title: `${season} ${year}`,
+        image: images[season],
+      };
+    };
+
+    const curSeason = this.getSeason(curMonth);
+
+    // Add the next season to the data
+    const nextSeason = this.getSeason(curMonth + 3);
+    const nextSeasonYear = curSeason === 'Fall' ? curYear + 1 : curYear;
+    data.push(getData(nextSeason, nextSeasonYear));
+
+    // Add all the seasons up to the current season in the current year
+    for (let i = seasons.indexOf(curSeason); i < 4; i += 1) {
+      data.push(getData(seasons[i], curYear));
+    }
+
+    // All all the seasons from previous years
+    for (let year = curYear - 1; year >= minYear; year -= 1) {
+      seasons.forEach((season) => {
+        data.push(getData(season, year));
+      });
+    }
+
+    return data;
+  }
+
   handleViewAllPress = (title, type) => {
     this.props.navigation.navigate('SearchResults', {
       label: title,
@@ -52,24 +117,7 @@ class TopsList extends PureComponent {
       },
     ];
 
-    const seasonsData = [
-      {
-        title: 'Fall 2017',
-        image: require('kitsu/assets/img/seasons/Fall.png'),
-      },
-      {
-        title: 'Summer 2017',
-        image: require('kitsu/assets/img/seasons/Summer.png'),
-      },
-      {
-        title: 'Spring 2017',
-        image: require('kitsu/assets/img/seasons/Spring.png'),
-      },
-      {
-        title: 'Winter 2017',
-        image: require('kitsu/assets/img/seasons/Winter.png'),
-      },
-    ];
+    const seasonsData = this.getSeasonsData();
 
     const animeData = [
       {

--- a/src/screens/Search/SeasonScreen.js
+++ b/src/screens/Search/SeasonScreen.js
@@ -1,0 +1,104 @@
+import React, { PureComponent } from 'react';
+import { TouchableOpacity, StyleSheet, ScrollView } from 'react-native';
+import { ContentList } from 'kitsu/components/ContentList';
+import PropTypes from 'prop-types';
+import FontAwesomeIcon from 'react-native-vector-icons/FontAwesome';
+import * as colors from 'kitsu/constants/colors';
+
+const styles = StyleSheet.create({
+  button: {
+    padding: 10,
+  },
+  scrollContainer: {
+    flex: 1,
+    backgroundColor: colors.lightPurple,
+  },
+});
+
+class SeasonScreen extends PureComponent {
+  static navigationOptions = ({ navigation }) => ({
+    title: navigation.state.params.label,
+    headerLeft: (
+      <TouchableOpacity onPress={() => navigation.goBack()} style={styles.button}>
+        <FontAwesomeIcon name="chevron-left" style={{ color: 'white' }} />
+      </TouchableOpacity>
+    ),
+  });
+
+  getSeasonData(year) {
+    const seasons = [
+      {
+        title: 'Winter',
+        image: require('kitsu/assets/img/seasons/Winter.png'),
+      },
+      {
+        title: 'Spring',
+        image: require('kitsu/assets/img/seasons/Spring.png'),
+      },
+      {
+        title: 'Summer',
+        image: require('kitsu/assets/img/seasons/Summer.png'),
+      },
+      {
+        title: 'Fall',
+        image: require('kitsu/assets/img/seasons/Fall.png'),
+      },
+    ];
+
+    const data = [];
+    seasons.forEach((season) => {
+      data.push({
+        ...season,
+        onPress: () => { this.handleSeasonPress(season, year); },
+      });
+    });
+
+    return data;
+  }
+
+  handleSeasonPress(season, year) {
+    // TODO: Hookup search page by season here
+    console.log(`${season.title} ${year}`);
+  }
+
+  render() {
+    const { maxYear, minYear, navigation: { navigate } } = this.props;
+
+    const listData = [];
+    for (let i = maxYear; i >= minYear; i -= 1) {
+      listData.push({
+        title: `${i}`,
+        dark: (i % 2) === 0,
+        data: this.getSeasonData(i),
+        type: 'static',
+        showViewAll: false,
+      });
+    }
+
+    return (
+      <ScrollView style={styles.scrollContainer}>
+        {listData.map(listItem => (
+          <ContentList
+            {...listItem}
+            key={listItem.title}
+            navigate={navigate}
+            onPress={() => console.log('Pressed')}
+          />
+        ))}
+      </ScrollView>
+    );
+  }
+}
+
+SeasonScreen.propTypes = {
+  minYear: PropTypes.number,
+  maxYear: PropTypes.number,
+  navigation: PropTypes.object.isRequired,
+};
+
+SeasonScreen.defaultProps = {
+  minYear: 1980,
+  maxYear: new Date().getFullYear() + 1,
+};
+
+export default SeasonScreen;

--- a/src/screens/Search/index.js
+++ b/src/screens/Search/index.js
@@ -3,5 +3,6 @@ import SearchCategory from './SearchCategory';
 import SearchFilter from './SearchFilter';
 import SearchResults from './SearchResults';
 import FilterSub from './FilterSub';
+import SeasonScreen from './SeasonScreen';
 
-export { SearchScreen, SearchCategory, SearchFilter, SearchResults, FilterSub };
+export { SearchScreen, SearchCategory, SearchFilter, SearchResults, FilterSub, SeasonScreen };


### PR DESCRIPTION
**Changes:**

- Seasons will update dynamically on the anime explore/search page.
    - It will show the next season, current season and the previous 2 years worth of seasons.
- Fixed ContentList styling.
    - Made it look more like the horizontal list in the media pages (scrolling goes all the way to the edge of the screen).
- Added placeholder items when anime/manga top lists are being loaded.
- Added a visibility prop for `View All` since not all list items needed it.
- Added a SeasonScreen which can be accessed when users tap `View All` in `Anime By Seasons`.
- Removed unnecessary lists from Manga (Seasons, Streaming)

-----

**To Do / Issues to be fixed:**

- Hook up Season, Streaming and Category taps to search results.
- When top anime/manga is loading, UI is blocked (i.e can’t view manga or click view all). Not sure if this is just emulator lag but it was present when testing for android.
- On android, the navigation ui gets messed up.
![screenshot_1513126466](https://user-images.githubusercontent.com/4365065/33916662-0401ba5a-dffe-11e7-80c4-58287bf734e5.png)

