### PR TITLE
Comment pagination, replies, and likes

### DIFF
--- a/src/config/api.js
+++ b/src/config/api.js
@@ -750,6 +750,22 @@ Kitsu.define(
 );
 
 Kitsu.define(
+  'commentLikes',
+  {
+    id: '',
+    createdAt: '',
+    updatedAt: '',
+    comment: {
+      jsonApi: 'hasOne',
+    },
+    user: {
+      jsonApi: 'hasOne',
+    },
+  },
+  { collectionPath: 'comment-likes' },
+);
+
+Kitsu.define(
   'userFeed',
   {
     createdAt: '',

--- a/src/screens/Feed/components/Comment/component.js
+++ b/src/screens/Feed/components/Comment/component.js
@@ -105,14 +105,12 @@ export class Comment extends PureComponent {
           users: 'avatar,name',
         },
         include: 'user',
-        sort: 'createdAt',
-        page: {
-          limit: 5
-        },
+        sort: '-createdAt',
+        page: { limit: 5 },
         ...requestOptions,
       });
 
-      this.setState({ replies: [...replies, ...this.state.replies] });
+      this.setState({ replies: [...replies.reverse(), ...this.state.replies] });
     } catch (err) {
       console.log('Error fetching replies: ', err);
     } finally {

--- a/src/screens/Feed/components/Comment/component.js
+++ b/src/screens/Feed/components/Comment/component.js
@@ -34,6 +34,7 @@ export class Comment extends PureComponent {
     await this.fetchReplies({
       page: {
         offset: this.state.replies.length,
+        limit: 5,
       },
     });
     this.setState({ isLoadingNextPage: false });
@@ -52,6 +53,9 @@ export class Comment extends PureComponent {
         },
         include: 'user',
         sort: 'createdAt',
+        page: {
+          limit: 5
+        },
         ...requestOptions,
       });
 
@@ -176,7 +180,7 @@ export const ToggleReplies = ({ onPress, isLoading, repliesCount }) => (
     )}
     {!isLoading && (
       <TouchableOpacity onPress={onPress}>
-        <StyledText color="dark" size="xxsmall" bold>View comments ({repliesCount})</StyledText>
+        <StyledText color="dark" size="xxsmall" bold>View replies ({repliesCount})</StyledText>
       </TouchableOpacity>
     )}
   </View>

--- a/src/screens/Feed/components/Comment/component.js
+++ b/src/screens/Feed/components/Comment/component.js
@@ -15,7 +15,6 @@ export class Comment extends PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      isLiked: false,
       likesCount: props.comment.likesCount,
       like: null,
       replies: [],
@@ -45,7 +44,7 @@ export class Comment extends PureComponent {
       });
 
       const like = likes.length && likes[0];
-      if (this.mounted) this.setState({ like, isLiked: !!like });
+      if (this.mounted) this.setState({ like });
     } catch (err) {
       console.log('Error fetching likes: ', err);
     }
@@ -53,12 +52,11 @@ export class Comment extends PureComponent {
 
   toggleLike = async () => {
     try {
-      const { isLiked, likesCount, like } = this.state;
+      const { likesCount, like } = this.state;
       const { comment, currentUser } = this.props;
 
       this.setState({
-        isLiked: !isLiked,
-        likesCount: isLiked ? likesCount - 1 : likesCount + 1,
+        likesCount: !!like ? likesCount - 1 : likesCount + 1,
       });
 
       if (like) {
@@ -79,8 +77,7 @@ export class Comment extends PureComponent {
     } catch (err) {
       console.log('Error toggling like: ', err);
       this.setState({
-        isLiked: !isLiked,
-        likesCount: isLiked ? likesCount - 1 : likesCount + 1,
+        likesCount: !!like ? likesCount - 1 : likesCount + 1,
       });
     }
   }
@@ -140,7 +137,7 @@ export class Comment extends PureComponent {
       onReplyPress,
     } = this.props;
 
-    const { isLiked, likesCount, replies } = this.state;
+    const { like, likesCount, replies } = this.state;
 
     const { content, createdAt, user, repliesCount } = comment;
     const { avatar, name } = user;
@@ -164,14 +161,14 @@ export class Comment extends PureComponent {
             <View style={styles.commentActions}>
               <StyledText color="grey" size="xxsmall">{moment(createdAt).fromNow()}</StyledText>
               <TouchableOpacity onPress={this.toggleLike} style={styles.commentActionItem}>
-                <StyledText color="grey" size="xxsmall">{`Like${isLiked ? 'd' : ''}`}</StyledText>
+                <StyledText color="grey" size="xxsmall">{`Like${!!like ? 'd' : ''}`}</StyledText>
               </TouchableOpacity>
               <TouchableOpacity onPress={onReplyPress} style={styles.commentActionItem}>
                 <StyledText color="grey" size="xxsmall">Reply</StyledText>
               </TouchableOpacity>
               <View style={styles.commentActionItem}>
-                <Icon name={isLiked ? 'md-heart' : 'md-heart-outline'} style={[styles.likeIcon, isLiked && styles.likeIcon__active]} />
-                <StyledText color={isLiked ? 'red' : 'grey'} size="xxsmall">{likesCount}</StyledText>
+                <Icon name={!!like ? 'md-heart' : 'md-heart-outline'} style={[styles.likeIcon, !!like && styles.likeIcon__active]} />
+                <StyledText color={!!like ? 'red' : 'grey'} size="xxsmall">{likesCount}</StyledText>
               </View>
             </View>
           )}

--- a/src/screens/Feed/components/Comment/component.js
+++ b/src/screens/Feed/components/Comment/component.js
@@ -172,7 +172,7 @@ export class Comment extends PureComponent {
       post={this.props.post}
       comment={item}
       currentUser={this.props.currentUser}
-      onAvatarPress={() => this.navigateToUserProfile(item.user.id)}
+      onAvatarPress={() => this.props.navigation.navigate('ProfilePages', { userId: item.user.id })}
       onReplyPress={() => this.onReplyPress(item.user.name)}
     />
   )
@@ -284,6 +284,7 @@ Comment.propTypes = {
     repliesCount: PropTypes.number,
     createdAt: PropTypes.string,
   }).isRequired,
+  navigation: PropTypes.object,
   isTruncated: PropTypes.bool,
   onAvatarPress: PropTypes.func,
   onReplyPress: PropTypes.func,
@@ -295,7 +296,6 @@ Comment.defaultProps = {
   onReplyPress: null,
 };
 
-// TODO: Should change the design on this.
 export const ToggleReplies = ({ onPress, isLoading, repliesCount }) => (
   <View>
     {isLoading && (

--- a/src/screens/Feed/components/Comment/styles.js
+++ b/src/screens/Feed/components/Comment/styles.js
@@ -27,4 +27,8 @@ export const styles = StyleSheet.create({
   likeIcon__active: {
     color: colors.red,
   },
+  nestedComments: {
+    marginTop: 14,
+    marginLeft: 14
+  },
 });

--- a/src/screens/Feed/components/CommentTextInput/component.js
+++ b/src/screens/Feed/components/CommentTextInput/component.js
@@ -11,6 +11,7 @@ export class CommentTextInput extends PureComponent {
   static propTypes = {
     inputRef: PropTypes.func,
     currentUser: PropTypes.object.isRequired,
+    autoFocus: PropTypes.bool,
     placeholderText: PropTypes.string,
     showAvatar: PropTypes.bool,
     onSubmit: PropTypes.func,
@@ -20,6 +21,7 @@ export class CommentTextInput extends PureComponent {
 
   static defaultProps = {
     inputRef: null,
+    autoFocus: false,
     placeholderText: 'Write a comment...',
     showAvatar: true,
     onSubmit: null,
@@ -32,6 +34,7 @@ export class CommentTextInput extends PureComponent {
       inputRef,
       currentUser,
       showAvatar,
+      autoFocus,
       placeholderText,
       comment,
       onCommentChanged,
@@ -46,6 +49,7 @@ export class CommentTextInput extends PureComponent {
             <TextInput
               ref={inputRef}
               style={styles.textInputField}
+              autoFocus={autoFocus}
               placeholder={placeholderText}
               placeholderTextColor={colors.grey}
               onChangeText={onCommentChanged}

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -238,7 +238,13 @@ export class Post extends PureComponent {
               <FlatList
                 data={latestComments}
                 keyExtractor={keyExtractor}
-                renderItem={({ item }) => <Comment comment={item} isTruncated />}
+                renderItem={({ item }) => {
+                  return <Comment
+                    comment={item}
+                    onAvatarPress={() => navigation.navigate('ProfilePages', { userId: user.id })}
+                    isTruncated
+                  />
+                }}
                 ItemSeparatorComponent={() => <View style={{ height: 17 }} />}
               />
             </PostSection>

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -39,7 +39,7 @@ export class Post extends PureComponent {
   state = {
     comment: '',
     comments: [],
-    latestComment: null,
+    latestComments: [],
     like: null,
     overlayRemoved: false,
   };
@@ -101,9 +101,9 @@ export class Post extends PureComponent {
         sort: 'createdAt',
       });
 
-      const latestComment = comments[comments.length - 1];
+      const latestComments = comments.slice(comments.length - 2);
 
-      if (this.mounted) this.setState({ latestComment, comments });
+      if (this.mounted) this.setState({ latestComments, comments });
     } catch (err) {
       console.log('Error fetching comments: ', err);
     }
@@ -178,7 +178,7 @@ export class Post extends PureComponent {
       commentsCount,
       user,
     } = this.props.post;
-    const { comment, latestComment, overlayRemoved } = this.state;
+    const { comment, latestComments, overlayRemoved } = this.state;
 
     let postBody = null;
 
@@ -223,12 +223,17 @@ export class Post extends PureComponent {
         />
 
         <PostFooter>
-          {commentsCount > 0 && !latestComment &&
+          {commentsCount > 0 && latestComments.length === 0 &&
             <SceneLoader />
           }
-          {latestComment && (
+          {latestComments.length > 0 && (
             <PostSection>
-              <Comment comment={latestComment} isTruncated />
+              <FlatList
+                data={latestComments}
+                keyExtractor={keyExtractor}
+                renderItem={({ item }) => <Comment comment={item} isTruncated />}
+                ItemSeparatorComponent={() => <View style={{ height: 17 }} />}
+              />
             </PostSection>
           )}
 

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -102,12 +102,15 @@ export class Post extends PureComponent {
           users: 'avatar,name',
         },
         include: 'user',
-        sort: 'createdAt',
+        sort: '-createdAt',
       });
 
-      const latestComments = comments.slice(comments.length - 2);
-
-      if (this.mounted) this.setState({ latestComments, comments });
+      if (this.mounted) {
+        this.setState({
+          latestComments: comments.slice(0, 2).reverse(),
+          comments: comments.reverse(),
+        });
+      }
     } catch (err) {
       console.log('Error fetching comments: ', err);
     }

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -92,6 +92,7 @@ export class Post extends PureComponent {
       const comments = await Kitsu.findAll('comments', {
         filter: {
           postId: this.props.post.id,
+          parentId: '_none',
         },
         fields: {
           users: 'avatar,name',
@@ -99,13 +100,6 @@ export class Post extends PureComponent {
         include: 'user',
         sort: 'createdAt',
       });
-
-      // TODO: Comments come in without any structure.
-      // We need to hook them up with parent / child comments,
-      // but Devour doesn't seem to do this correctly:
-      // https://github.com/twg/devour/issues/90
-      // and there's no way for me to access the relationship
-      // data from the raw response from this context.
 
       const latestComment = comments[comments.length - 1];
 

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -67,7 +67,7 @@ export class Post extends PureComponent {
   onCommentChanged = comment => this.setState({ comment })
 
   onSubmitComment = async () => {
-    await Kitsu.create('comments', {
+    const comment = await Kitsu.create('comments', {
       content: this.state.comment,
       post: {
         id: this.props.post.id,
@@ -78,9 +78,13 @@ export class Post extends PureComponent {
         type: 'users',
       },
     });
+    comment.user = this.props.currentUser;
 
-    this.setState({ comment: '' });
-    this.fetchComments();
+    this.setState({
+      comment: '',
+      comments: [...this.state.comments, comment],
+      latestComments: [...this.state.latestComments, comment]
+    });
   }
 
   mounted = false

--- a/src/screens/Feed/index.js
+++ b/src/screens/Feed/index.js
@@ -58,6 +58,9 @@ class Feed extends React.PureComponent {
   fetchFeed = async ({ reset = false } = {}) => {
     const PAGE_SIZE = 10;
 
+    if (this.isFetchingFeed) { return; }
+    this.isFetchingFeed = true;
+
     if (reset) this.cursor = undefined;
 
     try {
@@ -102,6 +105,8 @@ class Feed extends React.PureComponent {
         data: [],
         error,
       });
+    } finally {
+      this.isFetchingFeed = false;
     }
   };
 

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -67,7 +67,7 @@ export default class PostDetails extends PureComponent {
     try {
       const { currentUser, post } = this.props.navigation.state.params;
 
-      await Kitsu.create('comments', {
+      const comment = await Kitsu.create('comments', {
         content: this.state.comment,
         post: {
           id: post.id,
@@ -78,10 +78,9 @@ export default class PostDetails extends PureComponent {
           type: 'users',
         },
       });
+      comment.user = currentUser;
 
-      this.setState({ comment: '' });
-      // TODO: Insert new comment into stack
-      // this.fetchComments();
+      this.setState({ comment: '', comments: [...this.state.comments, comment] });
     } catch (err) {
       console.log('Error fetching comments: ', err);
     }
@@ -89,13 +88,11 @@ export default class PostDetails extends PureComponent {
 
   onPagination = async () => {
     this.setState({ isLoadingNextPage: true });
-
     await this.fetchComments({
       page: {
         offset: this.state.comments.length,
       },
     });
-
     this.setState({ isLoadingNextPage: false });
   };
 

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -183,6 +183,7 @@ export default class PostDetails extends PureComponent {
         post={post}
         comment={item}
         currentUser={currentUser}
+        navigation={this.props.navigation}
         onAvatarPress={() => this.navigateToUserProfile(item.user.id)}
       />
     );

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -79,7 +79,7 @@ export default class PostDetails extends PureComponent {
 
       this.setState({ comment: '', comments: [...this.state.comments, comment] });
     } catch (err) {
-      console.log('Error fetching comments: ', err);
+      console.log('Error submitting comment: ', err);
     }
   };
 
@@ -177,13 +177,13 @@ export default class PostDetails extends PureComponent {
   };
 
   renderItem = ({ item }) => {
-    const { currentUser } = this.props.navigation.state.params;
+    const { currentUser, post } = this.props.navigation.state.params;
     return (
       <Comment
+        post={post}
         comment={item}
         currentUser={currentUser}
         onAvatarPress={() => this.navigateToUserProfile(item.user.id)}
-        onReplyPress={this.focusOnCommentInput}
       />
     );
   };

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -180,13 +180,17 @@ export default class PostDetails extends PureComponent {
     this.props.navigation.navigate('ProfilePages', { userId });
   };
 
-  renderItem = ({ item }) => (
-    <Comment
-      comment={item}
-      onAvatarPress={() => this.navigateToUserProfile(item.user.id)}
-      onReplyPress={this.focusOnCommentInput}
-    />
-  );
+  renderItem = ({ item }) => {
+    const { currentUser } = this.props.navigation.state.params;
+    return (
+      <Comment
+        comment={item}
+        currentUser={currentUser}
+        onAvatarPress={() => this.navigateToUserProfile(item.user.id)}
+        onReplyPress={this.focusOnCommentInput}
+      />
+    );
+  };
 
   renderItemSeperatorComponent = () => <View style={{ height: 17 }} />;
 

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -130,11 +130,11 @@ export default class PostDetails extends PureComponent {
           users: 'avatar,name',
         },
         include: 'user',
-        sort: 'createdAt',
+        sort: '-createdAt',
         ...requestOptions,
       });
 
-      this.setState({ comments: [...comments, ...this.state.comments] });
+      this.setState({ comments: [...comments.reverse(), ...this.state.comments] });
     } catch (err) {
       console.log('Error fetching comments: ', err);
     }
@@ -160,10 +160,6 @@ export default class PostDetails extends PureComponent {
     } catch (err) {
       console.log('Error fetching likes: ', err);
     }
-  };
-
-  toggleLike = () => {
-    this.setState({ isLiked: !this.state.isLiked });
   };
 
   focusOnCommentInput = () => {

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -108,6 +108,7 @@ export default class PostDetails extends PureComponent {
       const comments = await Kitsu.findAll('comments', {
         filter: {
           postId: post.id,
+          parentId: '_none',
         },
         fields: {
           users: 'avatar,name',
@@ -115,13 +116,6 @@ export default class PostDetails extends PureComponent {
         include: 'user',
         sort: 'createdAt',
       });
-
-      // TODO: Comments come in without any structure.
-      // We need to hook them up with parent / child comments,
-      // but Devour doesn't seem to do this correctly:
-      // https://github.com/twg/devour/issues/90
-      // and there's no way for me to access the relationship
-      // data from the raw response from this context.
 
       this.setState({ comments });
     } catch (err) {

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -57,10 +57,8 @@ export default class PostDetails extends PureComponent {
 
   componentDidMount() {
     const { comments, like } = this.props.navigation.state.params;
-    if (!comments || !like) {
-      this.fetchComments();
-      this.fetchLikes();
-    }
+    if (!comments) { this.fetchComments(); }
+    if (!like) { this.fetchLikes(); }
   }
 
   onCommentChanged = comment => this.setState({ comment });

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -5,8 +5,7 @@ import {
   View,
   StatusBar,
   ScrollView,
-  TouchableOpacity,
-  ActivityIndicator
+  TouchableOpacity
 } from 'react-native';
 import { PropTypes } from 'prop-types';
 
@@ -22,10 +21,8 @@ import {
 } from 'kitsu/screens/Feed/components/Post';
 import { CommentTextInput } from 'kitsu/screens/Feed/components/CommentTextInput';
 import { SceneLoader } from 'kitsu/components/SceneLoader';
-import { Comment } from 'kitsu/screens/Feed/components/Comment';
+import { Comment, CommentPagination } from 'kitsu/screens/Feed/components/Comment';
 import { isX, paddingX } from 'kitsu/utils/isX';
-import { StyledText } from 'kitsu/components/StyledText';
-import { listBackPurple } from 'kitsu/constants/colors';
 
 export default class PostDetails extends PureComponent {
   static navigationOptions = {
@@ -120,7 +117,7 @@ export default class PostDetails extends PureComponent {
     }
   };
 
-  fetchComments = async (requestOptions) => {
+  fetchComments = async (requestOptions = {}) => {
     try {
       const { post } = this.props.navigation.state.params;
 
@@ -273,25 +270,3 @@ export default class PostDetails extends PureComponent {
     );
   }
 }
-
-export const CommentPagination = ({ onPress, isLoading }) => (
-  <View style={{ marginBottom: 15 }}>
-    {isLoading && (
-      <ActivityIndicator color={listBackPurple} />
-    )}
-    {!isLoading && (
-      <TouchableOpacity onPress={onPress}>
-        <StyledText color="dark" size="xxsmall" bold>Show previous comments</StyledText>
-      </TouchableOpacity>
-    )}
-  </View>
-);
-
-CommentPagination.propTypes = {
-  onPress: PropTypes.func,
-  isLoading: PropTypes.bool
-};
-CommentPagination.defaultProps = {
-  onPress: null,
-  isLoading: false
-};

--- a/src/utils/preprocessFeed.js
+++ b/src/utils/preprocessFeed.js
@@ -6,6 +6,7 @@ export const preprocessFeed = (result) => {
 
   result.forEach((group) => {
     group.activities.forEach((activity) => {
+      if (!activity.subject) { return; }
       data.push(activity.subject);
 
       // Since we don't support comment posts properly yet,


### PR DESCRIPTION
This PR grew a little larger than I would have liked, sorry about that... first time with RN. Let me know any changes/cleanup needed!

#### Additions

- [x] Submit comment reply
- [x] Create/Destroy comment likes
- [x] Pagination on comment & replies
- [x] Profile navigation on all comments

#### Changes

- Changed logic so we don't re-request comments when a posts has zero likes.
- Increased comment display from 1 -> 2 on home feed page
- Handle weird case when an activity returned from stream API didn't have a target (de-sync between DB/Stream maybe?)

#### Issues

- Avatar's on comments seem to re-render upon any state change