### PR TITLE
[Fix] URLs not being clickable on both devices.

### DIFF
--- a/src/common/utils/url.js
+++ b/src/common/utils/url.js
@@ -1,4 +1,3 @@
-import { includes } from 'lodash';
 import { Linking } from 'react-native';
 
 /**
@@ -19,6 +18,36 @@ async function openUrl(url) {
 }
 
 /**
+ * Extract protocol, host, hostname, port, pathname, search and hash from a given URL.
+ * Note: URL must not be relative or this function will return null.
+ *
+ * @param {string} url the url.
+ * @returns a Dictionary or null if not a valid url.
+ */
+function extractURLInfo(url) {
+  /**
+   * The Regex below is as follows:
+    '^(https?:)//', protocol
+    '(([^:/?#]*)(?::([0-9]+))?)', host (hostname and port)
+    '(/{0,1}[^?#]*)', pathname
+    '(\\?[^#]*|)', search params
+    '(#.*|)$' hash
+  */
+  const regex = /^(https?:)\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/;
+  const match = url.match(regex);
+  return match && {
+    url,
+    protocol: match[1],
+    host: match[2],
+    hostname: match[3],
+    port: match[4],
+    pathname: match[5],
+    search: match[6],
+    hash: match[7],
+  };
+}
+
+/**
  * Checks to see if `url` belongs to Kitsu.
  * If so then it will navigate to the corresponding page in the app
  * Otherwise it will pass it to `Linking`
@@ -27,11 +56,19 @@ async function openUrl(url) {
  * @param {object} navigation The navigation object.
  */
 export async function handleURL(url, navigation) {
-  const { hostname, pathname } = new URL(url);
+
+  // Get url information
+  const info = extractURLInfo(url);
+  if (!info) {
+    openUrl(url);
+    return;
+  }
+
+  const { hostname, pathname } = info;
   const paths = pathname.split('/').slice(1);
 
   // If it's not a kitsu url then we open it
-  if (!includes(hostname.toLowerCase(), 'kitsu') || paths.length < 2) {
+  if (!hostname.toLowerCase().includes('kitsu') || paths.length < 2) {
     openUrl(url);
     return;
   }

--- a/src/common/utils/url.js
+++ b/src/common/utils/url.js
@@ -24,7 +24,7 @@ async function openUrl(url) {
  * @param {string} url the url.
  * @returns a Dictionary or null if not a valid url.
  */
-function extractURLInfo(url) {
+function parseURL(url) {
   /**
    * The Regex below is as follows:
     '^(https?:)//', protocol
@@ -58,7 +58,7 @@ function extractURLInfo(url) {
 export async function handleURL(url, navigation) {
 
   // Get url information
-  const info = extractURLInfo(url);
+  const info = parseURL(url);
   if (!info) {
     openUrl(url);
     return;


### PR DESCRIPTION
- Added custom URL parser
    - We were using `URL` object before but that doesn't exist in iOS and Android.
