### PR TITLE
[Fix]More on-boarding issues

### DIFF
--- a/src/routes/onboarding.js
+++ b/src/routes/onboarding.js
@@ -51,6 +51,8 @@ const OnboardingStack = StackNavigator(
     Tabs: {
       screen: Tabs,
     },
+    // BUG HERE: After onboarding, if user logs out then they get taken to intro screen
+    // but they can't go to the auth screen unless they restart the app
     Intro: {
       screen: IntroScreen,
     },

--- a/src/screens/Auth/AuthScreen.js
+++ b/src/screens/Auth/AuthScreen.js
@@ -73,7 +73,7 @@ class AuthScreen extends React.Component {
     const { navigation } = this.props;
     const { email, username, password, confirmPassword, birthday, isBirthdaySet } = this.state;
     if (isFb) {
-      this.props.loginUser(null, navigation, 'signup');
+      this.props.loginUser(null, navigation, 'login');
     } else if (
       isEmpty(email) ||
       isEmpty(username) ||

--- a/src/screens/Intro/RegistrationScreen.js
+++ b/src/screens/Intro/RegistrationScreen.js
@@ -62,11 +62,12 @@ class RegistrationScreen extends React.Component {
   };
 
   loginFacebook = () => {
+    const { navigation } = this.props;
     this.setState({ loggingUser: true });
     LoginManager.logInWithReadPermissions(['public_profile']).then(
       (result) => {
         if (!result.isCancelled) {
-          this.props.loginUser(null, navigation, 'signup');
+          this.props.loginUser(null, navigation, 'registration');
         } else {
           this.setState({ loggingUser: false });
         }

--- a/src/screens/Onboarding/Aozora/CreateAccountScreen.js
+++ b/src/screens/Onboarding/Aozora/CreateAccountScreen.js
@@ -5,12 +5,13 @@ import { Input } from 'kitsu/components/Input';
 import { connect } from 'react-redux';
 import { updateGeneralSettings } from 'kitsu/store/user/actions';
 import { setScreenName } from 'kitsu/store/onboarding/actions';
-import isEmpty from 'lodash/isEmpty';
+import { isEmpty, isNull } from 'lodash';
 import { styles as commonStyles } from '../common/styles';
+import { styles } from './styles';
 
 class CreateAccountScreen extends React.Component {
   state = {
-    email: this.props.currentUser.email,
+    email: this.props.currentUser.email || this.props.fbuser.email || '',
     username: this.props.currentUser.name,
     password: '',
     confirmPassword: '',
@@ -37,15 +38,19 @@ class CreateAccountScreen extends React.Component {
 
       // Only continue if user has set the name and email
       if (!isEmpty(username) && !isEmpty(email)) {
+        let error = null;
 
         // Update the values if we need
         if (!isEmpty(valuesToUpdate)) {
-          await this.props.updateGeneralSettings(valuesToUpdate);
+          error = await this.props.updateGeneralSettings(valuesToUpdate);
         }
 
-        this.setState({ password: '', confirmPassword: '', shouldShowValidationInput: false });
-        this.props.setScreenName('FavoritesScreen');
-        navigation.navigate('FavoritesScreen');
+        // Only continue if we don't have an error
+        if (isNull(error)) {
+          this.setState({ password: '', confirmPassword: '', shouldShowValidationInput: false });
+          this.props.setScreenName('FavoritesScreen');
+          navigation.navigate('FavoritesScreen');
+        }
       }
     } else {
       if (Platform.OS === 'android') {
@@ -58,12 +63,16 @@ class CreateAccountScreen extends React.Component {
 
   render() {
     const { email, username, password, confirmPassword, usernameConfirmed } = this.state;
-    const { currentUser } = this.props;
+    const { currentUser, error, loading } = this.props;
     const isValidPass = password.length >= 8 && password === confirmPassword;
     const passwordSet = currentUser.hasPassword || isValidPass;
 
     const passwordText = passwordSet ? 'Looks good!' : 'You need to set a password!';
-    const buttonText = !usernameConfirmed ? 'Confirm Username' : passwordText;
+    const usernameText = !usernameConfirmed ? 'Confirm Username' : passwordText;
+
+    const isEmailValid = !isEmpty(email) && email.includes('@');
+    const fieldsEmpty = !isEmailValid || isEmpty(username);
+    const buttonText = fieldsEmpty ? 'Please fill out the fields above' : usernameText;
 
     return (
       <View style={commonStyles.container}>
@@ -107,21 +116,30 @@ class CreateAccountScreen extends React.Component {
           <View />
         )}
         <Button
-          disabled={!passwordSet && usernameConfirmed}
+          disabled={fieldsEmpty || (!passwordSet && usernameConfirmed)}
           style={{ marginTop: 36 }}
           onPress={this.onConfirm}
           title={buttonText}
           titleStyle={commonStyles.buttonTitleStyle}
+          loading={loading}
         />
+        { !isEmpty(error) &&
+          <View style={styles.errorContainer}>
+            <Text style={styles.errorText}>
+              An Error Occurred: {error.detail || 'Something went wrong!'}
+            </Text>
+          </View>
+        }
       </View>
     );
   }
 }
 
-const mapStateToProps = ({ onboarding, user }) => {
+const mapStateToProps = ({ onboarding, user, auth }) => {
   const { conflicts: accounts } = onboarding;
-  const { loading, error, currentUser } = user;
-  return { loading, error, currentUser, accounts };
+  const { loading, generalSettingError: error, currentUser } = user;
+  const { fbuser } = auth;
+  return { loading, error, currentUser, accounts, fbuser };
 };
 export default connect(mapStateToProps, { updateGeneralSettings, setScreenName })(
   CreateAccountScreen,

--- a/src/screens/Onboarding/Aozora/CreateAccountScreen.js
+++ b/src/screens/Onboarding/Aozora/CreateAccountScreen.js
@@ -67,12 +67,12 @@ class CreateAccountScreen extends React.Component {
     const isValidPass = password.length >= 8 && password === confirmPassword;
     const passwordSet = currentUser.hasPassword || isValidPass;
 
+    const isEmailValid = !isEmpty(email) && email.includes('@');
+    const fieldsValid = isEmailValid && !isEmpty(username);
+
     const passwordText = passwordSet ? 'Looks good!' : 'You need to set a password!';
     const usernameText = !usernameConfirmed ? 'Confirm Username' : passwordText;
-
-    const isEmailValid = !isEmpty(email) && email.includes('@');
-    const fieldsEmpty = !isEmailValid || isEmpty(username);
-    const buttonText = fieldsEmpty ? 'Please fill out the fields above' : usernameText;
+    const buttonText = !fieldsValid ? 'Please fill out the fields above' : usernameText;
 
     return (
       <View style={commonStyles.container}>
@@ -116,7 +116,7 @@ class CreateAccountScreen extends React.Component {
           <View />
         )}
         <Button
-          disabled={fieldsEmpty || (!passwordSet && usernameConfirmed)}
+          disabled={!fieldsValid || (!passwordSet && usernameConfirmed)}
           style={{ marginTop: 36 }}
           onPress={this.onConfirm}
           title={buttonText}

--- a/src/screens/Onboarding/Aozora/styles.js
+++ b/src/screens/Onboarding/Aozora/styles.js
@@ -49,4 +49,13 @@ export const styles = StyleSheet.create({
     resizeMode: 'contain',
     bottom: -32,
   },
+  errorContainer: {
+    flex: 1,
+    padding: 8,
+  },
+  errorText: {
+    color: colors.white,
+    textAlign: 'center',
+    fontWeight: 'bold',
+  },
 });

--- a/src/screens/Onboarding/common/ManageLibrary.js
+++ b/src/screens/Onboarding/common/ManageLibrary.js
@@ -16,7 +16,7 @@ const getTitle = (selectedAccount, hasRatedAnimes) => {
 
 const getButtonTitle = (selectedAccount, hasRatedAnimes, buttonIndex) => {
   if (buttonIndex === 0) {
-    if (selectedAccount === 'aozora') {
+    if (selectedAccount === 'aozora' || hasRatedAnimes) {
       return 'Start building manga library';
     }
     return 'Start building your library';
@@ -55,24 +55,31 @@ class ManageLibrary extends React.Component {
   render() {
     const { navigation, selectedAccount, accounts } = this.props;
     const { hasRatedAnimes } = navigation.state.params;
+
+    const kitsuAccountHasEntries = (
+      accounts && accounts.kitsu && accounts.kitsu.library_entries >= 5
+    );
+
+    const ratedAnime = hasRatedAnimes || kitsuAccountHasEntries;
+
     return (
       <View style={styles.container}>
         <View style={styles.contentWrapper}>
           <Text style={[styles.tutorialText, styles.tutorialText]}>
-            {getTitle(selectedAccount, hasRatedAnimes)}
+            {getTitle(selectedAccount, ratedAnime)}
           </Text>
           <Button
             style={[styles.button, { marginTop: 24 }]}
             onPress={() =>
-              onPress(navigation, selectedAccount, hasRatedAnimes, 0, this.completeOnboarding)}
-            title={getButtonTitle(selectedAccount, hasRatedAnimes, 0)}
+              onPress(navigation, selectedAccount, ratedAnime, 0, this.completeOnboarding)}
+            title={getButtonTitle(selectedAccount, ratedAnime, 0)}
             titleStyle={styles.buttonTitleStyle}
           />
           <Button
             style={[styles.button, styles.buttonSecondary]}
             onPress={() =>
-              onPress(navigation, selectedAccount, hasRatedAnimes, 1, this.completeOnboarding)}
-            title={getButtonTitle(selectedAccount, hasRatedAnimes, 1)}
+              onPress(navigation, selectedAccount, ratedAnime, 1, this.completeOnboarding)}
+            title={getButtonTitle(selectedAccount, ratedAnime, 1)}
             titleStyle={styles.buttonSecondaryTitle}
           />
         </View>

--- a/src/screens/Sidebar/Library/ImportLibrary.js
+++ b/src/screens/Sidebar/Library/ImportLibrary.js
@@ -25,10 +25,23 @@ const MediaItem = ({ onPress, title, details, image }) => (
   </TouchableOpacity>
 );
 
+const getTitleFromKind = (kind) => {
+  switch (kind.toLowerCase()) {
+    case 'my-anime-list':
+      return 'MyAnimeList';
+    case 'anilist':
+      return 'AniList';
+    case 'aozora':
+      return 'Aozora';
+    default:
+      return 'Unknown';
+  }
+};
+
 const ImportItem = ({ kind, status, date, total }) => {
   let icon = null;
   let details = '';
-  const title = kind === 'my-anime-list' ? 'MyAnimeList' : 'AniList';
+  const title = getTitleFromKind(kind);
   switch (status) {
     case 'running':
       icon = pending;

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -19,11 +19,11 @@ export const loginUser = (data, nav, screen) => async (dispatch, getState) => {
     }
   } else {
     try {
-      // The flow here is:
-      // If we get a 401 or 403 from the Kitsu server
-      // Send the user to the signup page
-      // Otherwise set the tokens
-      // which means a user account is already associated with the fb account
+      /**
+       * The flow here is:
+       * If we get a 401 or 403 from the Kitsu server, Send the user to the signup page.
+       * Otherwise set the tokens which means a user account is already associated with the fb account.
+      */
       const userFb = await loginUserFb(dispatch);
       if (![401, 403].includes(userFb.status)) {
         tokens = await userFb.json();
@@ -48,13 +48,13 @@ export const loginUser = (data, nav, screen) => async (dispatch, getState) => {
     dispatch({ type: types.LOGIN_USER_SUCCESS, payload: tokens });
     const user = await fetchCurrentUser()(dispatch, getState);
 
-    // Now over here, aozora users will always have their status set to aozora
-    // However for regular users we can't differentiate if they just signed up or not
-    // Thus we check the screen name to see if it's sign up
-    // If it is then we know they just signed up
-    // Note: signup is passed in `createUser`
-    // it shouldn't be passed in from anywhere else
-    // otherwise users might always be stuck in onboarding
+    /**
+     * Now over here, aozora users will always have their status set to `aozora`, until they complete onboarding which will set their status to `registered`.
+     * However for regular users we can't differentiate if they just signed up or not,since their status is always `registered` from the start.
+     * Thus we check the screen name to see if it's a `signup`.
+     * Note: `signup` is passed in from `createUser` function. It shouldn't be passed in from anywhere else
+       otherwise users might always be sent to onboarding when logging in with fb.
+    */
     if (user.status === 'aozora') {
       await getAccountConflicts()(dispatch, getState);
       const onboardingAction = NavigationActions.reset({

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -19,11 +19,25 @@ export const loginUser = (data, nav, screen) => async (dispatch, getState) => {
     }
   } else {
     try {
+      // The flow here is:
+      // If we get a 401 or 403 from the Kitsu server
+      // Send the user to the signup page
+      // Otherwise set the tokens
+      // which means a user account is already associated with the fb account
       const userFb = await loginUserFb(dispatch);
       if (![401, 403].includes(userFb.status)) {
         tokens = await userFb.json();
+      // We only navigate to the signup screen
+      // IF `createAccount` wasn't the one that called this function
       } else if (screen !== 'signup') {
-        nav.dispatch(NavigationActions.navigate({ routeName: 'Signup' }));
+        nav.dispatch(NavigationActions.reset({
+          index: 0,
+          actions: [NavigationActions.navigate({
+            routeName: 'AuthScreen',
+            params: { authType: 'signup' },
+          })],
+          key: null,
+        }));
       }
     } catch (e) {
       console.log(e);
@@ -33,7 +47,15 @@ export const loginUser = (data, nav, screen) => async (dispatch, getState) => {
   if (tokens) {
     dispatch({ type: types.LOGIN_USER_SUCCESS, payload: tokens });
     const user = await fetchCurrentUser()(dispatch, getState);
-    if (screen === 'signup' && user.status !== 'registered') {
+
+    // Now over here, aozora users will always have their status set to aozora
+    // However for regular users we can't differentiate if they just signed up or not
+    // Thus we check the screen name to see if it's sign up
+    // If it is then we know they just signed up
+    // Note: signup is passed in `createUser`
+    // it shouldn't be passed in from anywhere else
+    // otherwise users might always be stuck in onboarding
+    if (user.status === 'aozora') {
       await getAccountConflicts()(dispatch, getState);
       const onboardingAction = NavigationActions.reset({
         index: 0,
@@ -41,7 +63,7 @@ export const loginUser = (data, nav, screen) => async (dispatch, getState) => {
         key: null,
       });
       nav.dispatch(onboardingAction);
-    } else if (user.status === 'aozora') {
+    } else if (user.status !== 'registered' || screen === 'signup') {
       await getAccountConflicts()(dispatch, getState);
       const onboardingAction = NavigationActions.reset({
         index: 0,

--- a/src/store/auth/actions.js
+++ b/src/store/auth/actions.js
@@ -20,7 +20,7 @@ export const loginUser = (data, nav, screen) => async (dispatch, getState) => {
   } else {
     try {
       const userFb = await loginUserFb(dispatch);
-      if (userFb.status !== 401) {
+      if (![401, 403].includes(userFb.status)) {
         tokens = await userFb.json();
       } else if (screen !== 'signup') {
         nav.dispatch(NavigationActions.navigate({ routeName: 'Signup' }));
@@ -33,7 +33,8 @@ export const loginUser = (data, nav, screen) => async (dispatch, getState) => {
   if (tokens) {
     dispatch({ type: types.LOGIN_USER_SUCCESS, payload: tokens });
     const user = await fetchCurrentUser()(dispatch, getState);
-    if (screen === 'signup') {
+    if (screen === 'signup' && user.status !== 'registered') {
+      await getAccountConflicts()(dispatch, getState);
       const onboardingAction = NavigationActions.reset({
         index: 0,
         actions: [NavigationActions.navigate({ routeName: 'Onboarding' })],

--- a/src/store/auth/reducer.js
+++ b/src/store/auth/reducer.js
@@ -70,7 +70,7 @@ export const authReducer = (state = INITIAL_STATE, action) => {
         ...action.payload.auth,
         loginError: null,
         signingIn: false,
-        fbuser: {},
+        fbError: '',
         rehydratedAt: new Date(),
       };
     default:

--- a/src/store/user/actions.js
+++ b/src/store/user/actions.js
@@ -152,8 +152,10 @@ export const updateGeneralSettings = data => async (dispatch, getState) => {
     await Kitsu.update('users', { id, ...payload });
     delete payload.password; // Don't keep password.
     dispatch({ type: types.UPDATE_GENERAL_SETTINGS_SUCCESS, payload });
+    return null;
   } catch (e) {
-    dispatch({ type: types.UPDATE_GENERAL_SETTINGS_FAIL });
+    dispatch({ type: types.UPDATE_GENERAL_SETTINGS_FAIL, payload: e && e[0] });
+    return (e && e[0]) || 'Something went wrong';
   }
 };
 

--- a/src/store/user/reducer.js
+++ b/src/store/user/reducer.js
@@ -5,6 +5,7 @@ const INITIAL_STATE = {
   currentUser: {},
   loading: false,
   error: '',
+  generalSettingError: '',
   signingUp: false,
   signupError: {},
   ifollow: {},
@@ -106,6 +107,7 @@ export const userReducer = (state = INITIAL_STATE, action) => {
       return {
         ...state,
         loading: false,
+        generalSettingError: '',
         currentUser: {
           ...state.currentUser,
           ...action.payload,
@@ -115,7 +117,7 @@ export const userReducer = (state = INITIAL_STATE, action) => {
       return {
         ...state,
         loading: false,
-        error: '', // TODO: handle the error ~ Toast?
+        generalSettingError: action.payload, // TODO: handle the error ~ Toast?
       };
     case types.UPDATE_LIBRARY_SETTINGS:
       return {
@@ -158,6 +160,8 @@ export const userReducer = (state = INITIAL_STATE, action) => {
         signingIn: false,
         signingUp: false,
         signupError: {},
+        error: '',
+        generalSettingError: '',
         rehydratedAt: new Date(),
       };
     default:


### PR DESCRIPTION
- Automatically skip anime library rating in on boarding if `kitsu` account has more than 5 library entries.
- Added error handling in `CreateAccountScreen`.
- Added pre-population of email field in `CreateAccountScreen` if user logged in with Facebook.
- Fixed up facebook login/signup flow.
- Fixed library import showing 'AniList' for 'Aozora' imports.