### PR TITLE
Feed Updates

### DIFF
--- a/src/screens/Feed/components/Comment/component.js
+++ b/src/screens/Feed/components/Comment/component.js
@@ -59,7 +59,7 @@ export class Comment extends PureComponent {
   }
 
   onReplyPress = (item) => {
-    this.props.onReplyPress(item.user.name, (comment) => {
+    this.props.onReplyPress(item.user, (comment) => {
       this.setState({
         replies: [...this.state.replies, comment],
         repliesCount: this.state.repliesCount + 1,
@@ -140,7 +140,7 @@ export class Comment extends PureComponent {
           parentId: this.props.comment.id,
         },
         fields: {
-          users: 'avatar,name',
+          users: 'slug,avatar,name',
         },
         include: 'user',
         sort: '-createdAt',

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -56,10 +56,19 @@ export class Post extends PureComponent {
       post: this.props.post,
       comments: this.state.comments,
       commentsCount: this.state.commentsCount,
+      topLevelCommentsCount: this.state.topLevelCommentsCount,
       like: this.state.like,
       isLiked: this.state.isLiked,
       postLikesCount: this.state.postLikesCount,
       currentUser: this.props.currentUser,
+      syncComments: (comments) => {
+        this.setState({
+          comments: [...this.state.comments, ...comments],
+          latestComments: [...this.state.latestComments, ...comments],
+          commentsCount: this.state.commentsCount + comments.length,
+          topLevelCommentsCount: this.state.commentsCount + comments.length
+        })
+      }
     });
   }
 

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -29,12 +29,16 @@ export class Post extends PureComponent {
     comment: '',
     comments: [],
     latestComments: [],
+    commentsCount: this.props.post.commentsCount,
+    topLevelCommentsCount: this.props.post.topLevelCommentsCount,
     like: null,
     isLiked: false,
     postLikesCount: this.props.post.postLikesCount,
     overlayRemoved: false,
     isPostingComment: false,
   };
+
+  mounted = false
 
   componentDidMount() {
     this.mounted = true;
@@ -51,6 +55,7 @@ export class Post extends PureComponent {
     this.props.onPostPress({
       post: this.props.post,
       comments: this.state.comments,
+      commentsCount: this.state.commentsCount,
       like: this.state.like,
       isLiked: this.state.isLiked,
       postLikesCount: this.state.postLikesCount,
@@ -88,16 +93,19 @@ export class Post extends PureComponent {
     });
     comment.user = this.props.currentUser;
 
-    const processed = preprocessFeedPost(comment);
-    this.setState({
-      comment: '',
-      comments: [...this.state.comments, processed],
-      latestComments: [...this.state.latestComments, processed],
-      isPostingComment: false,
-    });
+      const processed = preprocessFeedPost(comment);
+      this.setState({
+        comment: '',
+        comments: [...this.state.comments, processed],
+        latestComments: [...this.state.latestComments, processed],
+        topLevelCommentsCount: this.state.topLevelCommentsCount + 1,
+        commentsCount: this.state.commentsCount + 1,
+        isPostingComment: false,
+      });
+    } catch (error) {
+      console.log('Error submitting comment:', error);
+    }
   }
-
-  mounted = false
 
   fetchComments = async () => {
     try {
@@ -205,7 +213,6 @@ export class Post extends PureComponent {
       nsfw,
       spoiler,
       spoiledUnit,
-      commentsCount,
       user,
     } = post;
     const {
@@ -213,6 +220,7 @@ export class Post extends PureComponent {
       latestComments,
       overlayRemoved,
       postLikesCount,
+      commentsCount,
       isPostingComment,
     } = this.state;
 

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -86,21 +86,21 @@ export class Post extends PureComponent {
 
   onSubmitComment = async () => {
     if (isEmpty(this.state.comment.trim()) || this.state.isPostingComment) return;
-
     this.setState({ isPostingComment: true });
 
-    const comment = await Kitsu.create('comments', {
-      content: this.state.comment.trim(),
-      post: {
-        id: this.props.post.id,
-        type: 'posts',
-      },
-      user: {
-        id: this.props.currentUser.id,
-        type: 'users',
-      },
-    });
-    comment.user = this.props.currentUser;
+    try {
+      const comment = await Kitsu.create('comments', {
+        content: this.state.comment.trim(),
+        post: {
+          id: this.props.post.id,
+          type: 'posts',
+        },
+        user: {
+          id: this.props.currentUser.id,
+          type: 'users',
+        },
+      });
+      comment.user = this.props.currentUser;
 
       const processed = preprocessFeedPost(comment);
       this.setState({
@@ -108,11 +108,12 @@ export class Post extends PureComponent {
         comments: [...this.state.comments, processed],
         latestComments: [...this.state.latestComments, processed],
         topLevelCommentsCount: this.state.topLevelCommentsCount + 1,
-        commentsCount: this.state.commentsCount + 1,
-        isPostingComment: false,
+        commentsCount: this.state.commentsCount + 1
       });
     } catch (error) {
       console.log('Error submitting comment:', error);
+    } finally {
+      this.setState({ isPostingComment: false });
     }
   }
 

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -89,7 +89,6 @@ export class Post extends PureComponent {
     comment.user = this.props.currentUser;
 
     const processed = preprocessFeedPost(comment);
-
     this.setState({
       comment: '',
       comments: [...this.state.comments, processed],
@@ -110,7 +109,7 @@ export class Post extends PureComponent {
           parentId: '_none',
         },
         fields: {
-          users: 'avatar,name',
+          users: 'slug,avatar,name',
         },
         include: 'user',
         sort: '-createdAt',

--- a/src/screens/Feed/components/Post/component.js
+++ b/src/screens/Feed/components/Post/component.js
@@ -100,8 +100,6 @@ export class Post extends PureComponent {
 
   mounted = false
 
-  keyExtractor = (item, index) => index;
-
   fetchComments = async () => {
     try {
       // We go ahead and fetch the comments so if the user wants to view detail

--- a/src/screens/Feed/index.js
+++ b/src/screens/Feed/index.js
@@ -145,7 +145,7 @@ class Feed extends React.PureComponent {
     this.props.navigation.navigate('MediaPages', { mediaId, mediaType });
   };
 
-  keyExtractor = (item, index) => index;
+  keyExtractor = (item, index) => item.id;
 
   renderPost = ({ item }) => {
     // This dispatches based on the type of an entity to the correct

--- a/src/screens/Feed/index.js
+++ b/src/screens/Feed/index.js
@@ -145,7 +145,9 @@ class Feed extends React.PureComponent {
     this.props.navigation.navigate('MediaPages', { mediaId, mediaType });
   };
 
-  keyExtractor = (item, index) => item.id;
+  keyExtractor = (item, index) => {
+    return `${item.id}-${item.updatedAt}`;
+  }
 
   renderPost = ({ item }) => {
     // This dispatches based on the type of an entity to the correct

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -110,7 +110,6 @@ export default class PostDetails extends PureComponent {
       comment.user = currentUser;
 
       const processed = preprocessFeedPost(comment);
-
       this.setState({ comment: '', isReplying: false, isPostingComment: false });
 
       if (this.replyRef) {
@@ -135,16 +134,14 @@ export default class PostDetails extends PureComponent {
     this.setState({ isLoadingNextPage: false });
   };
 
-  onReplyPress = (comment, username, callback) => {
-    let name = username;
-    if (typeof username !== 'string') {
-      name = comment.user.name;
-    }
+  onReplyPress = (comment, user, callback) => {
+    const mention = user.slug || user.id;
+    const name = user.name;
     this.setState({
-      comment: `@${name} `,
+      comment: `@${mention} `,
       isReplying: true,
     });
-    this.replyRef = { comment, name, callback };
+    this.replyRef = { comment, mention, name, callback };
     this.focusOnCommentInput();
   };
 
@@ -194,7 +191,7 @@ export default class PostDetails extends PureComponent {
           parentId: '_none',
         },
         fields: {
-          users: 'avatar,name',
+          users: 'slug,avatar,name',
         },
         include: 'user',
         sort: '-createdAt',
@@ -254,7 +251,7 @@ export default class PostDetails extends PureComponent {
         currentUser={currentUser}
         navigation={this.props.navigation}
         onAvatarPress={id => this.navigateToUserProfile(id)}
-        onReplyPress={(name, callback) => this.onReplyPress(item, name, callback)}
+        onReplyPress={(user, callback) => this.onReplyPress(item, user, callback)}
         overlayColor={colors.offWhite}
       />
     );

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -115,7 +115,6 @@ export default class PostDetails extends PureComponent {
       this.setState({
         comment: '',
         isReplying: false,
-        isPostingComment: false,
         commentsCount: this.state.commentsCount + 1
       });
 
@@ -137,6 +136,7 @@ export default class PostDetails extends PureComponent {
       }
     } catch (err) {
       console.log('Error submitting comment: ', err);
+    } finally {
       this.setState({ isPostingComment: false });
     }
   };

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -83,7 +83,7 @@ export default class PostDetails extends PureComponent {
     this.setState({ isPostingComment: true });
 
     try {
-      const { currentUser, post } = this.props.navigation.state.params;
+      const { currentUser, post, syncComments } = this.props.navigation.state.params;
 
       // Check if this is a reply rather than a top-level comment
       let replyOptions = {};
@@ -127,6 +127,13 @@ export default class PostDetails extends PureComponent {
           comments: [...this.state.comments, processed],
           topLevelCommentsCount: this.state.topLevelCommentsCount + 1
         });
+
+        // This is a top-level comment, we want to let the upstream
+        // component know that this exists without a re-fetch.
+        // @Hack
+        if (syncComments) {
+          syncComments([processed]);
+        }
       }
     } catch (err) {
       console.log('Error submitting comment: ', err);

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -42,6 +42,8 @@ export default class PostDetails extends PureComponent {
       comments: props.navigation.state.params.comments && [
         ...props.navigation.state.params.comments,
       ],
+      topLevelCommentsCount: props.navigation.state.params.topLevelCommentsCount,
+      commentsCount: props.navigation.state.params.commentsCount,
       like: props.navigation.state.params.like,
       isLiked: props.navigation.state.params.isLiked,
       postLikesCount: props.navigation.state.params.postLikesCount,
@@ -110,13 +112,21 @@ export default class PostDetails extends PureComponent {
       comment.user = currentUser;
 
       const processed = preprocessFeedPost(comment);
-      this.setState({ comment: '', isReplying: false, isPostingComment: false });
+      this.setState({
+        comment: '',
+        isReplying: false,
+        isPostingComment: false,
+        commentsCount: this.state.commentsCount + 1
+      });
 
       if (this.replyRef) {
         this.replyRef.callback(comment);
         this.replyRef = null;
       } else {
-        this.setState({ comments: [...this.state.comments, processed] });
+        this.setState({
+          comments: [...this.state.comments, processed],
+          topLevelCommentsCount: this.state.topLevelCommentsCount + 1
+        });
       }
     } catch (err) {
       console.log('Error submitting comment: ', err);
@@ -263,10 +273,10 @@ export default class PostDetails extends PureComponent {
     // We expect to have navigated here using react-navigation, and it takes all our props
     // and jams them over into this crazy thing.
     const { currentUser, post } = this.props.navigation.state.params;
-    const { comment, comments, isLiked, postLikesCount, isPostingComment } = this.state;
+    const { comment, comments, commentsCount, topLevelCommentsCount, isLiked, postLikesCount,
+        isPostingComment } = this.state;
 
-    const { content, embed, commentsCount,
-      topLevelCommentsCount, media, spoiledUnit } = post;
+    const { content, embed, media, spoiledUnit } = post;
 
     return (
       <KeyboardAvoidingView


### PR DESCRIPTION
- Fixes issue with mentioning users by pulling down slugs and mentioning by slug or falling back to id.
- Fixes issue with comments being placed on incorrect posts after a refresh. This was due to using `index` as the key in the `FlatList`.
- Hack fix to sync comments between the `Feed` & `PostDetails` page. Prior to this change if you made a comment on the `PostDetails` page and navigated back, it would disappear until a complete feed refresh or app restart.
- Fixes issue with feed refresh not pulling down latest like and comment data for updated posts.