### PR TITLE
[Fix] Removed beta lanes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 branches:
   only:
   - master
-  - release
   - develop
 notifications:
   email:
@@ -59,10 +58,9 @@ matrix:
         - yarn install
       script:
         - cd android && ./gradlew clean
-        - if [ "$TRAVIS_BRANCH" = "develop" ]; then fastlane alpha_googleplay; fi
-        - if [ "$TRAVIS_BRANCH" == "release" ]; then
-            fastlane beta_googleplay;
-            fastlane beta_crashlytics;
+        - if [ "$TRAVIS_BRANCH" = "develop" ]; then
+            fastlane alpha_googleplay;
+            fastlane alpha_crashlytics;
           fi
         - if [ "$TRAVIS_BRANCH" = "master" ]; then fastlane release; fi
 
@@ -85,5 +83,5 @@ matrix:
       script:
         - cd ios
         # We don't need to check for release branch here because alpha/beta are all handled in TestFlight
-        - if [ "$TRAVIS_BRANCH" = "develop" ]; then fastlane alpha_beta_testflight; fi
+        - if [ "$TRAVIS_BRANCH" = "develop" ]; then fastlane alpha_testflight; fi
         - if [ "$TRAVIS_BRANCH" = "master" ]; then fastlane release; fi

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -55,8 +55,8 @@ platform :android do
     )
   end
 
-  desc "Submit a new Beta Build to Crashlytics"
-  lane :beta_crashlytics do |values|
+  desc "Submit a new Alpha Build to Crashlytics"
+  lane :alpha_crashlytics do |values|
     build()
 
     emails = values[:test_email] ? values[:test_email] : ['is@urihere.com'] # You can list more emails here
@@ -79,17 +79,6 @@ platform :android do
     build()
     supply(
       track: 'alpha',
-      skip_upload_metadata: true,
-      skip_upload_images: true,
-      skip_upload_screenshots: true
-    )
-  end
-
-  desc "Submit a new Beta Build to Google Play"
-  lane :beta_googleplay do
-    build()
-    supply(
-      track: 'beta',
       skip_upload_metadata: true,
       skip_upload_images: true,
       skip_upload_screenshots: true

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -118,11 +118,7 @@ platform :ios do
   end
 
   desc "Submit a new Alpha/Beta Build to Testflight"
-  lane :alpha_beta_testflight do
-    # Since TestFlight doesn't have alpha/beta tracks
-    # We just use this single lane.
-    # The only down side is that we don't get auto-submitting beta builds for external users
-    # We can fix that in the future
+  lane :alpha_testflight do
     build()
 
     # Auto submit for alpha testers


### PR DESCRIPTION
This is because both TestFlight and Google Play allow us to push an alpha build into beta manually and thus we don't need the beta automated processes.

Whenever we want to release beta, just promote the alpha build.