### PR TITLE
Fix editing status from library edit modal

### DIFF
--- a/src/screens/Profiles/UserLibrary/components/UserLibraryEditScreen/component.js
+++ b/src/screens/Profiles/UserLibrary/components/UserLibraryEditScreen/component.js
@@ -70,7 +70,7 @@ export class UserLibraryEditScreenComponent extends React.Component {
   }
 
   onStatusChanged = (libraryStatus) => {
-    this.setState({ libraryStatus });
+    this.setState({ status: libraryStatus });
   }
 
   onDeleteEntry = async () => {
@@ -139,7 +139,8 @@ export class UserLibraryEditScreenComponent extends React.Component {
   render() {
     const { canEdit, libraryEntry, libraryType, ratingSystem } = this.props.navigation.state.params;
     const maxProgress = this.getMaxProgress();
-
+    // { value: 'current', anime: 'Currently Watching', manga: 'Currently Reading' },
+    const status = STATUS_SELECT_OPTIONS.filter(item => item.value === this.state.status)[0][libraryType]
     return (
       <View style={styles.container}>
         <SimpleHeader
@@ -155,7 +156,9 @@ export class UserLibraryEditScreenComponent extends React.Component {
             <Text style={[styles.editRowLabel, styles.withValueLabel]}>
               Library Status
             </Text>
-            <Text style={styles.editRowValue}>Currently Watching</Text>
+            <Text style={styles.editRowValue}>
+              {status}
+            </Text>
           </View>
           {canEdit &&
             <SelectMenu options={this.selectOptions} onOptionSelected={this.onStatusChanged}>

--- a/src/screens/Profiles/UserLibrary/components/UserLibraryListCard/component.js
+++ b/src/screens/Profiles/UserLibrary/components/UserLibraryListCard/component.js
@@ -182,7 +182,7 @@ export class UserLibraryListCard extends React.Component {
           { libraryEntry.status !== this.props.libraryStatus &&
             <View style={styles.moved}>
               <View style={styles.horizontalRule} />
-              { HEADER_TEXT_MAPPING.includes(libraryEntry.status) ?
+              { (libraryEntry.status in HEADER_TEXT_MAPPING) ?
                 <Text style={styles.movedText}>
                   Moved to <Text style={styles.movedToText}>
                     {HEADER_TEXT_MAPPING[libraryEntry.status][libraryType]}


### PR DESCRIPTION
:arrow_up:

- Also fixes a bug with going back to the card screen after an edit. Can't call `includes` on an object.