### PR TITLE
[Fix] Canny keyboard overlap.

### DIFF
--- a/src/screens/Sidebar/CannyBoard/component.js
+++ b/src/screens/Sidebar/CannyBoard/component.js
@@ -82,7 +82,7 @@ class Board extends React.Component {
             <ActivityIndicator />
           </View>
           : <WebView
-            style={[styles.webView, { paddingBottom: keyboardHeight }]}
+            style={[styles.webView, { marginBottom: keyboardHeight }]}
             source={{
               uri,
             }}


### PR DESCRIPTION
Switched from padding to margin so web view scales properly on android