### PR TITLE
[Fix]Image cache bust

### DIFF
--- a/src/common/utils/url.js
+++ b/src/common/utils/url.js
@@ -33,6 +33,8 @@ export function parseURL(url) {
     '(\\?[^#]*|)', search params
     '(#.*|)$' hash
   */
+  if (typeof url !== 'string') return null;
+
   const regex = /^(https?:)\/\/(([^:/?#]*)(?::([0-9]+))?)([/]{0,1}[^?#]*)(\?[^#]*|)(#.*|)$/;
   const match = url.match(regex);
   return match && {

--- a/src/constants/app.js
+++ b/src/constants/app.js
@@ -9,4 +9,7 @@ export const defaultAvatar = `${kitsuConfig.assetsUrl}/default_avatar-ff0fd0e960
 
 export const defaultCover = `${kitsuConfig.assetsUrl}/default_cover-7bda2081d0823731a96bbb20b70f4fcf.png`;
 
+// The dimensions of the kitsu cover image
+export const coverImageDimensions = { width: 2400, height: 1000 };
+
 export const TERMS_URL = 'https://kitsu.io/terms';

--- a/src/screens/Profiles/ProfilePages/index.js
+++ b/src/screens/Profiles/ProfilePages/index.js
@@ -127,6 +127,7 @@ class ProfilePage extends PureComponent {
       }
 
       this.setState({ profile: data });
+      await fetchCurrentUser();
     } catch (err) {
       console.log('Error updating user:', err);
     } finally {

--- a/src/screens/Profiles/ProfilePages/index.js
+++ b/src/screens/Profiles/ProfilePages/index.js
@@ -20,6 +20,8 @@ import { isX, paddingX } from 'kitsu/utils/isX';
 import { isIdForCurrentUser } from 'kitsu/common/utils';
 import { fetchCurrentUser } from 'kitsu/store/user/actions';
 import { getImgixCoverImage } from 'kitsu/utils/coverImage';
+import { parseURL } from 'kitsu/common/utils/url';
+import { isEmpty } from 'lodash';
 import Summary from './pages/Summary';
 import { Feed } from './pages/Feed';
 
@@ -117,8 +119,14 @@ class ProfilePage extends PureComponent {
         id: userId,
         ...changes,
       }, { include: 'waifu' });
+
+      // Bust the cover cache
+      if (data && data.coverImage) {
+        const bustedCovers = this.applyCacheBust(data.coverImage);
+        data.coverImage = bustedCovers;
+      }
+
       this.setState({ profile: data });
-      await fetchCurrentUser();
     } catch (err) {
       console.log('Error updating user:', err);
     } finally {
@@ -129,6 +137,34 @@ class ProfilePage extends PureComponent {
   setActiveTab = (tab) => {
     this.setState({ active: tab });
   }
+
+  /**
+   * Apply image cache bust to the given object.
+   * This will loop through each object property and check if the value is a url
+   * If it is then it will try apply a cache bust if it's not present.
+   *
+   * @param {any} object An object to apply cache bust to
+   * @returns The cache busted object
+   */
+  applyCacheBust(object) {
+    if (typeof object !== 'object') return object;
+
+    const updated = object;
+    Object.keys(object).forEach((key) => {
+      const url = object[key];
+      const parsed = parseURL(url);
+      if (parsed) {
+        // If we have the url but don't have any search params in it
+        // Then we know we have to apply a cache buster
+        if (isEmpty(parsed.search) && !isEmpty(url)) {
+          updated[key] = `${url}?${Date.now()}`;
+        }
+      }
+    });
+
+    return updated;
+  }
+
 
   goBack = () => {
     this.props.navigation.goBack();
@@ -196,12 +232,12 @@ class ProfilePage extends PureComponent {
       const record = await Kitsu.create('follows', {
         follower: {
           id: this.props.currentUser.id,
-          type: 'users'
+          type: 'users',
         },
         followed: {
           id: userId,
-          type: 'users'
-        }
+          type: 'users',
+        },
       });
       this.setState({ follow: record, isLoadingFollow: false });
     } catch (err) {

--- a/src/screens/Profiles/components/EditModal/component.js
+++ b/src/screens/Profiles/components/EditModal/component.js
@@ -6,7 +6,7 @@ import { ModalHeader } from 'kitsu/screens/Feed/components/ModalHeader';
 import { InfoRow } from 'kitsu/screens/Profiles/components/InfoRow';
 import { Input } from 'kitsu/components/Input';
 import { SelectMenu } from 'kitsu/components/SelectMenu';
-import { defaultAvatar, defaultCover } from 'kitsu/constants/app';
+import { defaultAvatar, defaultCover, coverImageDimensions } from 'kitsu/constants/app';
 import * as colors from 'kitsu/constants/colors';
 import { cloneDeep } from 'lodash';
 import capitalize from 'lodash/capitalize';
@@ -94,7 +94,10 @@ export class EditModal extends Component {
     }
     return (
       <View style={styles.profileCoverWrapper}>
-        <TouchableOpacity activeOpacity={0.6} onPress={() => this.onMediaSelect('coverImage', 1200, 500)}>
+        <TouchableOpacity
+          activeOpacity={0.6}
+          onPress={() => this.onMediaSelect('coverImage', coverImageDimensions.width, coverImageDimensions.height)}
+        >
           <Image
             style={styles.profileCover}
             source={cover}

--- a/src/screens/Profiles/components/EditModal/component.js
+++ b/src/screens/Profiles/components/EditModal/component.js
@@ -12,13 +12,14 @@ import { cloneDeep } from 'lodash';
 import capitalize from 'lodash/capitalize';
 import ImagePicker from 'react-native-image-crop-picker';
 import { styles } from './styles';
+import { getImgixCoverImage } from 'kitsu/utils/coverImage';
 
 export class EditModal extends Component {
   static defaultProps = {
     user: null,
     visible: false,
     onCancel: null,
-    onConfirm: null
+    onConfirm: null,
   }
 
   state = {
@@ -88,10 +89,15 @@ export class EditModal extends Component {
 
   renderCoverComponent = () => {
     const { changeset, changes } = this.state;
-    let cover = { uri: (changeset.coverImage && changeset.coverImage.large) || defaultCover };
+
+    // Use the imgix cover here otherwise if we use original
+    // we may run into the problem where a users original cover is too large
+    // and it causes a crash on android :(
+    let cover = { uri: getImgixCoverImage(changeset.coverImage) || defaultCover };
     if ('coverImage' in changes) {
       cover = { uri: changes.coverImage };
     }
+
     return (
       <View style={styles.profileCoverWrapper}>
         <TouchableOpacity

--- a/src/screens/Profiles/components/EditModal/styles.js
+++ b/src/screens/Profiles/components/EditModal/styles.js
@@ -1,5 +1,6 @@
 import { StyleSheet, Dimensions } from 'react-native';
 import * as colors from 'kitsu/constants/colors';
+import { coverImageDimensions } from 'kitsu/constants/app';
 
 export const styles = StyleSheet.create({
   profileCoverWrapper: {
@@ -9,7 +10,7 @@ export const styles = StyleSheet.create({
 
   profileCover: {
     width: Dimensions.get('window').width,
-    height: Dimensions.get('window').width * (500 / 1200),
+    height: Dimensions.get('window').width * (coverImageDimensions.height / coverImageDimensions.width),
   },
 
   profileImageWrapper: {

--- a/src/screens/Profiles/constants.js
+++ b/src/screens/Profiles/constants.js
@@ -7,6 +7,7 @@ export const scene = {
 
 export const scenePadding = scene.width * 0.03;
 
+// The height of the cover image in relation to the scene
 export const coverImageHeight = scene.height * 0.35;
 
 export const spacing = {

--- a/src/utils/coverImage.js
+++ b/src/utils/coverImage.js
@@ -1,9 +1,11 @@
 import { parseURL } from 'kitsu/common/utils/url';
 import { kitsuConfig } from 'kitsu/config/env';
+import { coverImageDimensions } from 'kitsu/constants/app';
+import { isEmpty } from 'lodash';
 
 export const defaultImgixOptions = {
-  w: 1200,
-  'max-h': 500,
+  w: coverImageDimensions.width,
+  'max-h': coverImageDimensions.height,
   fit: 'crop',
   crop: 'faces,edges',
   auto: 'format',
@@ -36,16 +38,17 @@ export function getImgixCoverImage(coverImage, imageOptions = {}) {
   if (!coverURL) return null;
 
   // Parse it
-  const { hostname, pathname } = parseURL(coverURL);
+  const { hostname, pathname, search } = parseURL(coverURL);
   if (!hostname.toLowerCase().includes('kitsu')) return coverURL;
 
   // Build the search params
   const mappings = Object.keys(options).filter(k => options[k]).map(key => `${key}=${options[key]}`);
-
   const searchParams = mappings.join('&');
 
-  const imgixURL = `https://${kitsuConfig.imgixBaseUrl}${pathname}?${searchParams}`;
-  console.log(imgixURL);
+  // Replace host with imgix
+  // This also ensures we keep the cache buster number at the end of the url
+  const coverSearchParam = isEmpty(search) ? '?' : `${search}&`;
+  const imgixURL = `https://${kitsuConfig.imgixBaseUrl}${pathname}${coverSearchParam}${searchParams}`;
 
   return imgixURL;
 }


### PR DESCRIPTION
**Changes:**
- Fixed `getImgixCover` ignoring cache bust integer.
   - If a url now has no cache bust, then it will apply it automatically.
- Added image cache bust after user edits profile.
   - Before when a user edited the profile and it reloaded, the old cover image was shown. This now applies a cache bust which will show the new cover.
- Made `EditModal` use imgix covers.
- Fixed possible crash fixes when parsing url or getting imgix cover.
- Moved cover image dimensions to a constant.
- Doubled cover image dimension when changing cover so that you don't get blurry covers on the website.