### PR TITLE
[Fix] Fastlane android release

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -88,12 +88,23 @@ platform :android do
   desc "Release a new version to the Google Play"
   lane :release do
     build()
+
+    # For now this flow uses alpha since we can directly promote the app to publish from alpha
+    # However in the future this probably needs a revisit so the rollout process is easier
+    # TODO: Fix this flow up
     supply(
+      track: 'alpha',
       skip_upload_metadata: true,
       skip_upload_images: true,
-      skip_upload_screenshots: true,
-      check_superseded_tracks: true
+      skip_upload_screenshots: true
     )
+    
+    # Disabled this because it didn't seem to work :(
+    # supply(
+    #   skip_upload_metadata: true,
+    #   skip_upload_images: true,
+    #   skip_upload_screenshots: true
+    # )
   end
 
 

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -91,7 +91,8 @@ platform :android do
     supply(
       skip_upload_metadata: true,
       skip_upload_images: true,
-      skip_upload_screenshots: true
+      skip_upload_screenshots: true,
+      check_superseded_tracks: true
     )
   end
 


### PR DESCRIPTION
- Made it upload the build to the `alpha` track and from there we can manually promote it to production.
    - This needs to be looked into further in the future, but for now since we're kind of bogged down with bugs/crashes this should be fine.