### PR TITLE
[Fix] iOS 9 crash

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -119,7 +119,7 @@ android {
         targetSdkVersion 27
         missingDimensionStrategy "RNN.reactNativeVersion", "reactNative51"
         versionCode 1
-        versionName "6.9.1"
+        versionName "6.9.2"
         multiDexEnabled true
         ndk {
             abiFilters "armeabi-v7a", "x86"

--- a/ios/kitsu_mobile/Info.plist
+++ b/ios/kitsu_mobile/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.9.1</string>
+	<string>6.9.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kitsu_mobile",
-  "version": "6.9.1",
+  "version": "6.9.2",
   "private": true,
   "scripts": {
     "debug": "REACT_DEBUGGER=\"rndebugger-open --open --port 8081\" yarn start",

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -12,7 +12,7 @@ export const kitsuConfig = {
   assetsUrl: `${kitsuUrl}/images`,
   baseUrl: apiUrl,
   uploadUrl: `${apiUrl}/edge/uploads/_bulk`,
-  version: '6.9.1',
+  version: '6.9.2',
   stream: {
     API_KEY: 'eb6dvmba4ct3',
     API_SECRET:

--- a/src/navigation/index.js
+++ b/src/navigation/index.js
@@ -1,8 +1,16 @@
+import { Platform } from 'react-native';
 import { listBackPurple, tabRed, tabInactive } from 'kitsu/constants/colors';
 import * as Screens from './types';
 import * as Layouts from './layouts';
 import { registerScreens } from './screens';
 import * as NavigationActions from './actions';
+
+const majorVersionIOS = Platform.OS === 'ios' ? parseInt(Platform.Version, 10) : 0;
+
+// Setting badgeColor on iOS 9 causes crash
+const badgeColor = (Platform.OS === 'android' || majorVersionIOS >= 10) ? {
+  badgeColor: tabRed,
+} : {};
 
 
 // Default styling options
@@ -43,12 +51,12 @@ export const defaultOptions = {
     textColor: tabInactive,
     selectedTextColor: tabRed,
     selectedIconColor: tabRed,
-    badgeColor: tabRed,
     iconInsets: { // This is for iOS
       top: 6,
       bottom: -6,
       right: 0,
     },
+    ...badgeColor,
   },
 };
 


### PR DESCRIPTION
The fix before didn't work so i just disabled setting `badgeColor` if it's a iOS 9 device.