### PR TITLE
Add Edit and Delete functions to PostDetails screen

### DIFF
--- a/src/screens/Feed/components/Post/components/PostHeader/component.js
+++ b/src/screens/Feed/components/Post/components/PostHeader/component.js
@@ -116,6 +116,8 @@ PostHeader.propTypes = {
   onBackButtonPress: PropTypes.func,
   onAvatarPress: PropTypes.func,
   currentUser: PropTypes.object,
+  onEditPress: PropTypes.func,
+  onDelete: PropTypes.func
 };
 
 PostHeader.defaultProps = {
@@ -125,4 +127,6 @@ PostHeader.defaultProps = {
   onBackButtonPress: null,
   onAvatarPress: null,
   currentUser: null,
+  onEditPress: null,
+  onDelete: null
 };

--- a/src/screens/Feed/components/Post/components/PostStatus/component.js
+++ b/src/screens/Feed/components/Post/components/PostStatus/component.js
@@ -7,7 +7,7 @@ import { styles } from './styles';
 export const PostStatus = ({ showViewParent, likesCount, commentsCount, onPress }) => (
   <TouchableOpacity onPress={onPress} activeOpacity={0.9}>
     <View style={styles.postStatusRow}>
-      <StyledText color="grey" size="xxsmall">{likesCount} likes</StyledText>
+      <StyledText color="grey" size="xxsmall">{likesCount + (likesCount === 1 ? ' like' : ' likes')}</StyledText>
       {showViewParent && <StyledText color="grey" size="xxsmall">View Parent Post</StyledText>}
       <StyledText color="grey" size="xxsmall">{commentsCount} comments</StyledText>
     </View>

--- a/src/screens/Feed/pages/PostDetails.js
+++ b/src/screens/Feed/pages/PostDetails.js
@@ -328,11 +328,10 @@ export default class PostDetails extends PureComponent {
   deletePost = async () => {
     try {
       const { post } = this.state;
-      this.setState({ isDeleted: true });
       await Kitsu.destroy('posts', post.id);
+      // TODO: give user feedback when post deleted (go back to Feed?)
     } catch (err) {
       console.log('Error deleting post:', err);
-      this.setState({ isDeleted: false });
       Alert.alert('Sorry', 'There was an issue deleting the post.', [
         { text: 'OK', onPress: null },
       ]);


### PR DESCRIPTION
Fixes #429

The toggleEditor and deletePost functions were missing from the PostDetails screen, and weren't being passed into the PostHeader component. Added the two functions, passed them into the Header component and you can now edit a post from its detail screen.

This PR also updates language for "likes" to be singular if there is only one like on a post.

TODO: potentially sync the updated post content when returning to the feed so that you don't need to manually refresh the feed.