### PR TITLE
Renamed "Personal Notes" to "Notes" to avoid confusion.

### DIFF
--- a/src/screens/Profiles/UserLibrary/components/UserLibraryEditScreen/component.js
+++ b/src/screens/Profiles/UserLibrary/components/UserLibraryEditScreen/component.js
@@ -410,7 +410,7 @@ export class UserLibraryEditScreenComponent extends React.Component {
             <View style={[styles.editRow, { maxHeight: 'auto' }]}>
               <View style={styles.notesSection}>
                 <Text style={[styles.editRowLabel, styles.withValueLabel]}>
-                  Personal Notes
+                  Notes
                 </Text>
                 <TextInput
                   style={[styles.editRowValue]}


### PR DESCRIPTION
Users mistakenly think that their notes will be private.